### PR TITLE
Removing deprecated screen_icon().

### DIFF
--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -1124,7 +1124,6 @@ class WP_Import extends WP_Importer {
 	// Display import page title
 	function header() {
 		echo '<div class="wrap">';
-		screen_icon();
 		echo '<h2>' . __( 'Import WordPress', 'wordpress-importer' ) . '</h2>';
 
 		$updates = get_plugin_updates();


### PR DESCRIPTION
Issue #16 - Remove the usage of screen_icon() which has been long deprecated.