### PR TITLE
Add a unit test checking comment slashing

### DIFF
--- a/phpunit/data/slashes.xml
+++ b/phpunit/data/slashes.xml
@@ -65,13 +65,23 @@
 		<wp:is_sticky>0</wp:is_sticky>
 		<category domain="category" nicename="alpha"><![CDATA[a \"great\" category]]></category>
 		<wp:postmeta>
-			<wp:meta_key>Post by</wp:meta_key>
-			<wp:meta_value><![CDATA[admin]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
 			<wp:meta_key>_edit_last</wp:meta_key>
 			<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
+		<wp:comment>
+			<wp:comment_id>1</wp:comment_id>
+			<wp:comment_author><![CDATA[Mr WordPress]]></wp:comment_author>
+			<wp:comment_author_email></wp:comment_author_email>
+			<wp:comment_author_url>http://wordpress.org/</wp:comment_author_url>
+			<wp:comment_author_IP></wp:comment_author_IP>
+			<wp:comment_date>2011-01-18 20:53:18</wp:comment_date>
+			<wp:comment_date_gmt>2011-01-18 20:53:18</wp:comment_date_gmt>
+			<wp:comment_content><![CDATA[\o/ ¯\_(ツ)_/¯]]></wp:comment_content>
+			<wp:comment_approved>1</wp:comment_approved>
+			<wp:comment_type></wp:comment_type>
+			<wp:comment_parent>0</wp:comment_parent>
+			<wp:comment_user_id>0</wp:comment_user_id>
+		</wp:comment>
 	</item>
 </channel>
 </rss>

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -284,7 +284,16 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 				'post_status' => 'any',
 			)
 		);
+		$this->assertNotEmpty( $posts );
 		$this->assertSame( 'Slashes aren\\\'t \"cool\"', $posts[0]->post_content );
+
+		$comments = get_comments(
+			array(
+				'post_id' => $posts[0]->post_ID
+			)
+		);
+		$this->assertNotEmpty( $comments );
+		$this->assertSame( '\o/ ¯\_(ツ)_/¯', $comments[0]->comment_content );
 	}
 
 	// function test_menu_import


### PR DESCRIPTION
Add Comment slashing unit test from https://core.trac.wordpress.org/attachment/ticket/21007/21007.2.diff

The fix was added in https://github.com/WordPress/wordpress-importer/commit/53a7def30e2376608d903af71e60ffc636cfbc1c but there existed no unit test for it.

Thanks to @ocean90 