### PR TITLE
Added base_blog_url field

### DIFF
--- a/src/parsers.php
+++ b/src/parsers.php
@@ -411,7 +411,7 @@ class WXR_Parser_XML {
 				break;
 			case 'wp:base_site_url':
 				$this->base_url = $this->cdata;
-				if( !isset( $this->base_blog_url ) {
+				if( !isset( $this->base_blog_url ) ) {
 					$this->base_blog_url = $this->cdata;
 				}
 				break;

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -92,7 +92,7 @@ class WXR_Parser_SimpleXML {
 		$base_url = (string) trim( $base_url[0] );
 		
 		$base_blog_url = $xml->xpath('/rss/channel/wp:base_blog_url');
-		if( $base_blog_url ) {
+		if ( $base_blog_url ) {
 			$base_blog_url = (string) trim( $base_blog_url[0] );
 		} else {
 			$base_blog_url = $base_url;
@@ -411,7 +411,7 @@ class WXR_Parser_XML {
 				break;
 			case 'wp:base_site_url':
 				$this->base_url = $this->cdata;
-				if( !isset( $this->base_blog_url ) ) {
+				if ( ! isset( $this->base_blog_url ) ) {
 					$this->base_blog_url = $this->cdata;
 				}
 				break;

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -92,7 +92,11 @@ class WXR_Parser_SimpleXML {
 		$base_url = (string) trim( $base_url[0] );
 		
 		$base_blog_url = $xml->xpath('/rss/channel/wp:base_blog_url');
-		$base_blog_url = (string) trim( $base_blog_url[0] );
+		if( $base_blog_url ) {
+			$base_blog_url = (string) trim( $base_blog_url[0] );
+		} else {
+			$base_blog_url = $base_url;
+		}
 
 		$namespaces = $xml->getDocNamespaces();
 		if ( ! isset( $namespaces['wp'] ) )
@@ -410,6 +414,9 @@ class WXR_Parser_XML {
 				break;
 			case 'wp:base_blog_url':
 				$this->base_blog_url = $this->cdata;
+				if ( !$this->base_blog_url ) {
+					$this->base_blog_url = $this->base_url;
+				}
 				break;
 			case 'wp:wxr_version':
 				$this->wxr_version = $this->cdata;
@@ -475,6 +482,8 @@ class WXR_Parser_Regex {
 					preg_match( '|<wp:base_blog_url>(.*?)</wp:base_blog_url>|is', $importline, $blog_url );
 					$this->base_blog_url = $blog_url[1];
 					continue;
+				} else {
+					$this->base_blog_url = $this->base_url;	
 				}
 
 				if ( false !== strpos( $importline, '<wp:author>' ) ) {

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -411,12 +411,12 @@ class WXR_Parser_XML {
 				break;
 			case 'wp:base_site_url':
 				$this->base_url = $this->cdata;
+				if( !isset( $this->base_blog_url ) {
+					$this->base_blog_url = $this->cdata;
+				}
 				break;
 			case 'wp:base_blog_url':
 				$this->base_blog_url = $this->cdata;
-				if ( !$this->base_blog_url ) {
-					$this->base_blog_url = $this->base_url;
-				}
 				break;
 			case 'wp:wxr_version':
 				$this->wxr_version = $this->cdata;

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -90,6 +90,9 @@ class WXR_Parser_SimpleXML {
 
 		$base_url = $xml->xpath('/rss/channel/wp:base_site_url');
 		$base_url = (string) trim( $base_url[0] );
+		
+		$base_blog_url = $xml->xpath('/rss/channel/wp:base_blog_url');
+		$base_blog_url = (string) trim( $base_blog_url[0] );
 
 		$namespaces = $xml->getDocNamespaces();
 		if ( ! isset( $namespaces['wp'] ) )
@@ -259,6 +262,7 @@ class WXR_Parser_SimpleXML {
 			'tags' => $tags,
 			'terms' => $terms,
 			'base_url' => $base_url,
+			'base_blog_url' => $base_blog_url,
 			'version' => $wxr_version
 		);
 	}
@@ -312,6 +316,7 @@ class WXR_Parser_XML {
 			'tags' => $this->tag,
 			'terms' => $this->term,
 			'base_url' => $this->base_url,
+			'base_blog_url' => $this->base_blog_url,
 			'version' => $this->wxr_version
 		);
 	}
@@ -403,6 +408,9 @@ class WXR_Parser_XML {
 			case 'wp:base_site_url':
 				$this->base_url = $this->cdata;
 				break;
+			case 'wp:base_blog_url':
+				$this->base_blog_url = $this->cdata;
+				break;
 			case 'wp:wxr_version':
 				$this->wxr_version = $this->cdata;
 				break;
@@ -431,7 +439,8 @@ class WXR_Parser_Regex {
 	var $tags = array();
 	var $terms = array();
 	var $base_url = '';
-
+	var $base_blog_url = '';
+	
 	function __construct() {
 		$this->has_gzip = is_callable( 'gzopen' );
 	}
@@ -459,6 +468,12 @@ class WXR_Parser_Regex {
 				if ( false !== strpos( $importline, '<wp:base_site_url>' ) ) {
 					preg_match( '|<wp:base_site_url>(.*?)</wp:base_site_url>|is', $importline, $url );
 					$this->base_url = $url[1];
+					continue;
+				}
+				
+				if ( false !== strpos( $importline, '<wp:base_blog_url>' ) ) {
+					preg_match( '|<wp:base_blog_url>(.*?)</wp:base_blog_url>|is', $importline, $blog_url );
+					$this->base_blog_url = $blog_url[1];
 					continue;
 				}
 
@@ -508,6 +523,7 @@ class WXR_Parser_Regex {
 			'tags' => $this->tags,
 			'terms' => $this->terms,
 			'base_url' => $this->base_url,
+			'base_blog_url' => $this->base_blog_url,
 			'version' => $wxr_version
 		);
 	}


### PR DESCRIPTION
I added the `base_blog_url` variable,

This is needed to fix importing multiple files bug in WP-CLI https://github.com/wp-cli/import-command/pull/27

The problem is that WP-importer files from WPMU have the same base url for every blog, to recognise their  url the `base_blog_url` is needed. Having this we will able to group the processed post IDs correctly.