### PR TITLE
Add ability to prevent remote fetches

### DIFF
--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -994,7 +994,7 @@ class WP_Import extends WP_Importer {
 		// don't fetch files, if requested
 		$prevent = defined( 'IMPORT_PREVENT_REMOTE_FETCH' ) && IMPORT_PREVENT_REMOTE_FETCH;
 		if ( apply_filters( 'import_prevent_remote_fetch', $prevent, $url, $post )) {
-			printf( __( "Skipping fetch of '%s'\n", 'wordpress-importer' ), $url );
+			printf( __( "Skipping fetch of '%s'<br />\n", 'wordpress-importer' ), $url );
 			$upload_dir = wp_upload_dir( $post['upload_date'] );
 			$attachment_url = sprintf( '%s/%s', $upload_dir['url'], $file_name );
 			$attachment_filename = sprintf( '%s/%s', $upload_dir['path'], $file_name );


### PR DESCRIPTION
Hello — Figured I'd open this PR to see if there was any interest. If not, that's okay.

The use case is actually a real-world scenario I'm dealing with right now :)

I've got a site with over 2,000 attachments I'm trying to import into an existing site. To speed things up, I downloaded all the files inside the uploads directory to my local machine via FTP.

I then created an export on the source site (All content + Media) and then started an import on the destination site. Problem is, the destination site still wants to download all the files from the source site even though they already exist locally.

With this PR, a new constant for wp-config.php is introduced (`IMPORT_PREVENT_REMOTE_FETCH`) and when set to true the `fetch_remote_file()` function is short-circuited to return an array of info on the locally existing file for the attachment. There is also a `import_prevent_remote_fetch` filter that receives the value of the constant, the URL, and the attachment to provide more fine-tuned control.

Looking forward to any feedback. Thanks!