### PR TITLE
Source the WP_Import class regardless of request context

### DIFF
--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -10,9 +10,6 @@ Text Domain: wordpress-importer
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 
-if ( ! defined( 'WP_LOAD_IMPORTERS' ) )
-	return;
-
 /** Display verbose errors */
 define( 'IMPORT_DEBUG', false );
 
@@ -1224,6 +1221,10 @@ class WP_Import extends WP_Importer {
 } // class_exists( 'WP_Importer' )
 
 function wordpress_importer_init() {
+	if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
+		return;
+	}
+
 	load_plugin_textdomain( 'wordpress-importer' );
 
 	/**


### PR DESCRIPTION
This change short-circuits the instantiation instead of the declaration of the `WP_Import` class (& other backing resources).

This is instead of preventing the file from being sourced altogether when the `WP_LOAD_IMPORTERS` constant is not defined.

As is, it's difficult (if not impossible) to modify that constant in a plugin prior to its evaluation here.

---

I inspected what runs when the file is sourced and there doesn't seem to be anything that's resource intensive or that would introduce side-effects.