### PR TITLE
Update Travis script & minimum WP requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-sudo: false
 dist: trusty
 language: php
 
 cache:
   directories:
     - vendor
-    - $HOME/.composer/cache
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
 
 env:
   global:
@@ -13,31 +15,39 @@ env:
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.3
       env: WP_VERSION=trunk
-    - php: 7.2
+    - php: 7.3
       env: WP_VERSION=latest
+    - php: 7.3
+      env: WP_VERSION=3.7
+    - php: 7.2
     - php: 7.1
     - php: 7.0
     - php: 5.6
     - php: 5.5
+      env: WP_VERSION=5.1
     - php: 5.4
+      env: WP_VERSION=5.0
     - php: 5.3
+      env: WP_VERSION=4.9
       dist: precise
     - php: 5.2
+      env: WP_VERSION=5.1
       dist: precise
-    - php: nightly
+    - php: 5.2
+      env: WP_VERSION=4.0
+      dist: precise
+    - php: "7.4snapshot"
+    - php: "nightly"
+
   allow_failures:
+    - php: "7.4snapshot"
     - php: nightly
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - |
-    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
-      phpenv config-rm xdebug.ini
-    else
-      echo "xdebug.ini does not exist"
-    fi
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   - |
     bash phpunit/install.sh wordpress_test root '' localhost $WP_VERSION
     if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
-Requires at least: 3.6
+Requires at least: 3.7
 Tested up to: 4.9
 Stable tag: 0.6.4
 License: GPLv2 or later


### PR DESCRIPTION
* Don't use `sudo`. This is [no longer supported on Travis](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
* Cache the correct directories for Composer.
* Add testing against PHP 7.3 and PHP 7.4 (dev).
* Simplify the Xdebug removal command.
* Fix the test matrix.
    WP `trunk/latest` no longer support PHP < 5.6.20.
    The plugin claims to support WP 3.6 and higher, however this can no longer be tested as due to a change in the unit test setup of WP Core in WP 3.7, the unit tests can not be run in combination with WP 3.6 anymore.
    So for the highest stable PHP version, add a build against the lowest testable WP version, 3.7 and update the minimum WP requirement to WP 3.7.
    For the lowest supported PHP version, `5.2`, a build against WP 3.7 fails with warnings about incorrect use of `wpdb::prepare()`, so, for now, test this against a low version which doesn't fail on those warnings.
    And for all other PHP versions below 5.6.20, fix the WP version being tested against at a version below WP 5.2.