### PR TITLE
Bug fix: term meta data not importing

### DIFF
--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -425,7 +425,7 @@ class WP_Import extends WP_Importer {
 			$catarr = wp_slash( $catarr );
 
 			$id = wp_insert_category( $catarr );
-			if ( ! is_wp_error( $id ) ) {
+			if ( ! is_wp_error( $id ) && $id > 0 ) {
 				if ( isset($cat['term_id']) )
 					$this->processed_terms[intval($cat['term_id'])] = $id;
 			} else {
@@ -436,7 +436,7 @@ class WP_Import extends WP_Importer {
 				continue;
 			}
 
-			$this->process_termmeta( $cat, $id['term_id'] );
+			$this->process_termmeta( $cat, $id );
 		}
 
 		unset( $this->categories );


### PR DESCRIPTION
The [`wp_insert_category()`](https://developer.wordpress.org/reference/functions/wp_insert_category/) function returns the integer ID number of the new or updated Category on success or Zero or a `WP_Error` on failure.

### Bug 1

While the code checks the return value of `wp_insert_category()` for `WP_Error`, it doesn't ask for a `WP_Error` by passing the second parameter `$wp_error` to `wp_insert_category()`.

This means that even when the insert/update failed and `wp_insert_category()` returns `0`, the code will still try to process the terms as well as the termmeta.

This bug has existed in the code from before this plugin was available on GitHub.

### Bug 2

When processing the termmeta, `$id['term_id']` is passed as the second argument.
However, as stated above, `wp_insert_category()` - when successful - will return the integer ID number, not an array with the key `term_id`.

Trying to access the integer `$id` as if it were an array will silently return `null`, though as of PHP 7.4, this will throw an `E_WARNING`.

And when `process_termmeta()` receives `null` as the `$term_ID`, it will effectively never import the term meta data, let alone assign it to the correct term.

This second bug was introduced in 3d9c2d3ad9c623641a44c7260afcd3a8d1d2e1b4 (aug 2016) which introduced support for term metadata to the plugin.

This patch fixes both bugs.

Fixes #51
Fixes #46

Related to https://core.trac.wordpress.org/ticket/47704

**Note**: the build failures against PHP 5.2-5.5 are unrelated to this PR and will be fixed once PR #52 has been merged.
If so desired, I'll happily rebase this PR once #52 has been merged to demonstrate this.