### PR TITLE
Set Accept-Encoding header to identity for download.

### DIFF
--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1070,7 +1070,7 @@ class WP_Import extends WP_Importer {
 
 		$uploads = wp_upload_dir( $post['upload_date'] );
 		if ( ! ( $uploads && false === $uploads['error'] ) ) {
-			return new WP_Error( 'upload_dir_error', $upload['error'] );
+			return new WP_Error( 'upload_dir_error', $uploads['error'] );
 		}
 
 		// Move the file to the uploads dir.

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -994,9 +994,12 @@ class WP_Import extends WP_Importer {
 
 		// Fetch the remote URL and write it to the placeholder file.
 		$remote_response = wp_safe_remote_get( $url, array(
-			'timeout'  => 300,
-			'stream'   => true,
-			'filename' => $tmp_file_name,
+			'timeout'    => 300,
+			'stream'     => true,
+			'filename'   => $tmp_file_name,
+			'headers'    => array(
+				'Accept-Encoding' => 'identity',
+			),
 		) );
 
 		$remote_response_code = (int) wp_remote_retrieve_response_code( $remote_response );
@@ -1024,7 +1027,7 @@ class WP_Import extends WP_Importer {
 
 		if ( isset( $headers['content-length'] ) && $filesize !== (int) $headers['content-length'] ) {
 			@unlink( $tmp_file_name );
-			return new WP_Error( 'import_file_error', __('Remote file is incorrect size', 'wordpress-importer' ) );
+			return new WP_Error( 'import_file_error', __('Downloaded file has incorrect size', 'wordpress-importer' ) );
 		}
 
 		$max_size = (int) $this->max_attachment_size();

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1025,7 +1025,7 @@ class WP_Import extends WP_Importer {
 			return new WP_Error( 'import_file_error', __('Zero size file downloaded', 'wordpress-importer') );
 		}
 
-		if ( isset( $headers['content-length'] ) && $filesize !== (int) $headers['content-length'] ) {
+		if ( ! isset( $headers['content-encoding'] ) && isset( $headers['content-length'] ) && $filesize !== (int) $headers['content-length'] ) {
 			@unlink( $tmp_file_name );
 			return new WP_Error( 'import_file_error', __('Downloaded file has incorrect size', 'wordpress-importer' ) );
 		}


### PR DESCRIPTION
Ensures files are not compressed which may break the file size check after download.

Fixes #47.