### PR TITLE
Prevent duplicate postmeta records insertion

### DIFF
--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -895,7 +895,7 @@ class WP_Import extends WP_Importer {
 							$value = maybe_unserialize( $meta['value'] );
 						}
 
-						add_post_meta( $post_id, wp_slash( $key ), wp_slash_strings_only( $value ) );
+						update_post_meta( $post_id, wp_slash( $key ), wp_slash_strings_only( $value ) );
 
 						do_action( 'import_post_meta', $post_id, $key, $value );
 


### PR DESCRIPTION
**Issue**
- On import of already existing attachment/post/page, the importer gives error "Page/Post/Attachment  already exists." but imports the postmeta records from source.

**Fix**
- Replace the function to add postmeta only if it's not exist