### PR TITLE
PHP 8.0: only call libxml_disable_entity_loader() in PHP < 8

### DIFF
--- a/src/parsers/class-wxr-parser-simplexml.php
+++ b/src/parsers/class-wxr-parser-simplexml.php
@@ -21,7 +21,7 @@ class WXR_Parser_SimpleXML {
 
 		$dom       = new DOMDocument;
 		$old_value = null;
-		if ( function_exists( 'libxml_disable_entity_loader' ) ) {
+		if ( function_exists( 'libxml_disable_entity_loader' ) && PHP_VERSION_ID < 80000 ) {
 			$old_value = libxml_disable_entity_loader( true );
 		}
 		$success = $dom->loadXML( file_get_contents( $file ) );


### PR DESCRIPTION
As per the PHP 8.0 changelog:

> `libxml_disable_entity_loader()` has been deprecated. As libxml 2.9.0 is now
> required, external entity loading is guaranteed to be disabled by default,
> and this function is no longer needed to protect against XXE attacks.

Source: https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L808-L811

Calling the function conditionally will prevent deprecation warnings.

And while the `PHP_VERSION_ID` constant was introduced in PHP 5.2.7, no additional condition is needed to check for its existance as the condition won't be executed when the `libxml_disable_entity_loader()` function exists check fails and as `libxml_disable_entity_loader()` was introduced in PHP 5.2.11, this means, we're good.