### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: php
 
@@ -14,6 +14,9 @@ cache:
     # Cache directory for more recent Composer versions.
     - $HOME/.cache/composer
 
+services:
+  - mysql
+
 env:
   global:
     - WP_VERSION=latest
@@ -25,6 +28,7 @@ matrix:
     - php: 7.4
     - php: 7.3
     - php: 7.3
+      name: "PHPCS check"
       script:
         - |
           composer global require wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp dealerdirect/phpcodesniffer-composer-installer
@@ -34,10 +38,13 @@ matrix:
     - php: 7.0
     - php: 5.6
       env: WP_VERSION=3.7
+      dist: trusty
     - php: 5.5
       env: WP_VERSION=5.1
+      dist: trusty
     - php: 5.4
       env: WP_VERSION=5.0
+      dist: trusty
     - php: 5.3
       env: WP_VERSION=4.9
       dist: precise
@@ -48,22 +55,25 @@ matrix:
       env: WP_VERSION=4.0
       dist: precise
     - php: "nightly"
+      env: WP_VERSION=trunk
 
   allow_failures:
     - php: nightly
+      env: WP_VERSION=trunk
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+  - bash phpunit/install.sh wordpress_test root '' localhost $WP_VERSION
   - |
-    bash phpunit/install.sh wordpress_test root '' localhost $WP_VERSION
-    if [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then
-      composer global require "phpunit/phpunit=4.8.*|5.7.*|6.5.*|7.5.*"
+    if [[ "$TRAVIS_PHP_VERSION" == "nightly" ]]; then
+      composer global require phpunit/phpunit:"7.5.*" --ignore-platform-reqs
+    elif [[ "$TRAVIS_PHP_VERSION" != "5.2" ]]; then
+      composer global require phpunit/phpunit:"4.8.*||5.7.*||6.5.*||7.5.*"
     else
       echo "PHP 5.2: Skipping composer for PHPUnit, relying upon builtin PHPUnit."
     fi
 
 script:
-  - |
-    phpunit
-    WP_MULTISITE=1 phpunit
+  - phpunit
+  - WP_MULTISITE=1 phpunit


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Use the `xenial` distro, which at this time is the default.
* Adds `mysql` as a service as the Xenial image does not have it installed by default.
* Sets the distro for PHP versions not supported on Xenial explicitly to `trusty`.
    Note: PHP 5.6 is supposed to be supported, but runs into various database related errors when run against Xenial, so setting it to Trusty anyway.
* Gives a name to the PHPCS build to make it clearer that there are not two PHP 7.3 test runs, but that they actually do something different.
* Set the `WP_VERSION` for PHP 8/`nightly` to `trunk` as WP itself is not yet compatible with PHP 8 and `trunk` will be where the fixes go in.
* Installs PHPUnit on `nightly` with `--ignore-platform-reqs` as PHPUnit 7.x otherwise would not install on PHP 8.
* Fixes the syntax of the `composer require` commands.
* Runs the tests as two separate tasks as otherwise a failure of the first task may be hidden by the second task passing as Travis doesn't take both exit codes into account.