### PR TITLE
Using gzip is optional.

### DIFF
--- a/src/parsers/class-wxr-parser-regex.php
+++ b/src/parsers/class-wxr-parser-regex.php
@@ -19,7 +19,8 @@ class WXR_Parser_Regex {
 	var $base_blog_url = '';
 
 	function __construct() {
-		$this->has_gzip = is_callable( 'gzopen' );
+		$has_gzip       = is_callable( 'gzopen' );
+		$this->has_gzip = (bool) apply_filters( 'wp_import_has_gzip', $has_gzip ); 
 	}
 
 	function parse( $file ) {


### PR DESCRIPTION
In some environments like a shared folder, gzip is not reliable even if PHP has Gzip extension.
Related #41 