### PR TITLE
Raise minimum required WP version to WP 5.2 ( and PHP 5.6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,72 +22,34 @@ jobs:
       fail-fast: false
       matrix:
         # Notes regarding supported versions in WP:
-        # PHP 5.3-5.5 are supported since WP 3.7 until WP 5.1 (including).
-        # PHP 5.6 is supported since WP 4.1.
-        # PHP 7.0 is supported since WP 4.4.
-        # PHP 7.1 is supported since WP 4.7.
-        # PHP 7.2 is supported since WP 4.9.
-        # PHP 7.3 is supported since WP 5.0.
-        # PHP 7.4 is supported since WP 5.3.
-        # PHP 8.0 is sort of supported since WP 5.6.
-        # This doesn't mean that the plugin doesn't work on earlier version as it may not hit incompatible
-        # parts of WP, but just something to be aware of in case of failures.
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
-        wp: ['latest', '3.7']
+        # The base matrix only contains the PHP versions which are supported on all supported WP versions.
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        wp: ['latest', '5.2']
         experimental: [false]
 
         include:
-          # As support for PHP < 5.6 was dropped in WP 5.2, PHP 5.3 - 5.5 can only be tested against WP < 5.2.
-          # Complement the builds run via the matrix with high/low WP builds for PHP 5.3 - 5.5.
-          - php: '5.5'
-            wp: '5.1'
+          # Complement the builds run via the matrix with high/low WP builds for PHP 7.4 and 8.0.
+          # PHP 8.0 is sort of supported since WP 5.6.
+          # PHP 7.4 is supported since WP 5.3.
+          - php: '8.0'
+            wp: 'latest'
             experimental: false
-          - php: '5.5'
-            wp: '3.7'
+          - php: '8.0'
+            wp: '5.6'
             experimental: false
-          - php: '5.4'
-            wp: '5.1'
+          - php: '7.4'
+            wp: 'latest'
             experimental: false
-          - php: '5.4'
-            wp: '3.7'
-            experimental: false
-          - php: '5.3'
-            wp: '5.1'
-            experimental: false
-          - php: '5.3'
-            wp: '3.7'
-            experimental: false
-
-          # Complement the builds run via the matrix with some additional builds against specific WP versions.
           - php: '7.4'
             wp: '5.4'
             experimental: false
+
+          # Complement the builds run via the matrix with some additional builds against specific WP versions.
           - php: '7.3'
             wp: '5.3'
             experimental: false
-          - php: '7.2'
-            wp: '5.2'
-            experimental: false
-          - php: '7.1'
-            wp: '4.6'
-            experimental: false
-          - php: '7.0'
-            wp: '4.3'
-            experimental: false
-          - php: '5.6'
-            wp: '4.0'
-            experimental: false
           - php: '5.6'
             wp: '5.5'
-            experimental: false
-          - php: '5.5'
-            wp: '4.5'
-            experimental: false
-          - php: '5.4'
-            wp: '5.0'
-            experimental: false
-          - php: '5.3'
-            wp: '4.9'
             experimental: false
 
           # Experimental builds. These are allowed to fail.
@@ -101,15 +63,13 @@ jobs:
 
     services:
       mysql:
-        # WP 4.5 is the first WP version which properly supports MySQL 5.7.
-        # See: https://core.trac.wordpress.org/ticket/34692
         # WP 5.4 is the first WP version which largely supports MySQL 8.0.
         # See: https://core.trac.wordpress.org/ticket/49344
         # During the setting up of these tests, it became clear that MySQL 8.0
         # in combination with PHP < 7.4 is not properly/sufficiently supported
         # within WP Core.
         # See: https://core.trac.wordpress.org/ticket/52496
-        image: mysql:${{ ( matrix.wp < 4.5 && '5.6' ) || ( (matrix.wp < 5.4 || matrix.php < 7.4) && '5.7' ) || '8.0' }}
+        image: mysql:${{ ( matrix.wp == 5.3 && '5.6' ) || ( (matrix.wp < 5.4 || matrix.php < 7.4) && '5.7' ) || '8.0' }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
         ports:
@@ -131,9 +91,7 @@ jobs:
       - name: Set up WordPress
         run: phpunit/install.sh wordpress_test root '' 127.0.0.1:3306 ${{ matrix.wp }}
 
-      # Originally, only PHPUnit 4.x and 5.x were supported.
-      # As of WP 5.1, PHPUnit 6.x and 7.x are also supported.
-      # With WP 5.2 dropping support for PHP < 5.6, support for PHPUnit 4.x was also dropped.
+      # On WP 5.2, PHPUnit 5.x, 6.x and 7.x are supported.
       # On PHP >= 8.0, PHPUnit 7.5+ is needed, no matter what.
       - name: Determine supported PHPUnit version
         id: set_phpunit
@@ -141,13 +99,7 @@ jobs:
           if [[ "${{ matrix.php }}" > "7.4" ]]; then
             echo '::set-output name=PHPUNIT::7.5.*'
           else
-            if [[ "${{ matrix.wp }}" == "latest" || "${{ matrix.wp }}" == "trunk" || "${{ matrix.wp }}" > "5.1" ]]; then
-              echo '::set-output name=PHPUNIT::5.7.*||6.5.*||7.5.*'
-            elif [ "${{ matrix.wp }}" == "5.1" ]; then
-              echo '::set-output name=PHPUNIT::4.8.*||5.7.*||6.5.*||7.5.*'
-            else
-              echo '::set-output name=PHPUNIT::4.8.*||5.7.*'
-            fi
+            echo '::set-output name=PHPUNIT::5.7.*||6.5.*||7.5.*'
           fi
 
       - name: 'Composer: set up PHPUnit'

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,7 +44,7 @@
 -->
 
 	<!-- Supported PHP versions -->
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibilityWP"/>
 
 </ruleset>

--- a/phpunit/tests/term-meta.php
+++ b/phpunit/tests/term-meta.php
@@ -20,10 +20,6 @@ class Tests_Import_Term_Meta extends WP_Import_UnitTestCase {
 	}
 
 	function test_serialized_term_meta() {
-		if ( ! function_exists( 'get_term_meta' ) ) {
-			$this->markTestSkipped( 'Test only runs on WordPress 4.4.0.' );
-		}
-
 		register_taxonomy( 'custom_taxonomy', array( 'post' ) );
 
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-term-meta.xml', array( 'admin' => 'admin' ) );

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -564,10 +564,6 @@ class WP_Import extends WP_Importer {
 	 * @param int   $term_id ID of the newly created term.
 	 */
 	protected function process_termmeta( $term, $term_id ) {
-		if ( ! function_exists( 'add_term_meta' ) ) {
-			return;
-		}
-
 		if ( ! isset( $term['termmeta'] ) ) {
 			$term['termmeta'] = array();
 		}

--- a/src/compat.php
+++ b/src/compat.php
@@ -37,33 +37,3 @@ if ( ! function_exists( 'addslashes_strings_only' ) ) {
 		return is_string( $value ) ? addslashes( $value ) : $value;
 	}
 }
-
-if ( ! function_exists( 'map_deep' ) ) {
-	/**
-	 * Maps a function to all non-iterable elements of an array or an object.
-	 *
-	 * Compat for WordPress < 4.4.0.
-	 *
-	 * @since 0.7.0
-	 *
-	 * @param mixed    $value    The array, object, or scalar.
-	 * @param callable $callback The function to map onto $value.
-	 * @return mixed The value with the callback applied to all non-arrays and non-objects inside it.
-	 */
-	function map_deep( $value, $callback ) {
-		if ( is_array( $value ) ) {
-			foreach ( $value as $index => $item ) {
-				$value[ $index ] = map_deep( $item, $callback );
-			}
-		} elseif ( is_object( $value ) ) {
-			$object_vars = get_object_vars( $value );
-			foreach ( $object_vars as $property_name => $property_value ) {
-				$value->$property_name = map_deep( $property_value, $callback );
-			}
-		} else {
-			$value = call_user_func( $callback, $value );
-		}
-
-		return $value;
-	}
-}

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,8 +2,9 @@
 Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
-Requires at least: 3.7
-Tested up to: 5.3
+Requires at least: 5.2
+Tested up to: 5.6
+Requires PHP: 5.6
 Stable tag: 0.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -1,15 +1,18 @@
 <?php
 /*
-Plugin Name: WordPress Importer
-Plugin URI: https://wordpress.org/plugins/wordpress-importer/
-Description: Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
-Author: wordpressdotorg
-Author URI: https://wordpress.org/
-Version: 0.7
-Text Domain: wordpress-importer
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-*/
+ * @wordpress-plugin
+ * Plugin Name:       WordPress Importer
+ * Plugin URI:        https://wordpress.org/plugins/wordpress-importer/
+ * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
+ * Author:            wordpressdotorg
+ * Author URI:        https://wordpress.org/
+ * Version:           0.7
+ * Requires at least: 5.2
+ * Requires PHP:      5.6
+ * Text Domain:       wordpress-importer
+ * License:           GPLv2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ */
 
 if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
 	return;


### PR DESCRIPTION
### Raise minimum required WP version to WP 5.2 ( and PHP 5.6)

Includes:
* Adding `Requires PHP` headers.
* Updating the `Requires at least` (WP) headers.
* Stop detection of PHP compatibility issues for PHP < 5.6.
* CI: Stop testing on WP < 5.2 and PHP < 5.6.
    Note: the PHP 7.4 and 8.0 builds against WP 5.2 were running into trouble due to WP itself not being fully compatible, so the CI matrix has been adjusted to only test against those PHP versions on WP versions which claim to be compatible with those PHP versions.

Includes tidying up the file docblock in the `wordpress-importer.php` file.

Closes #95

### Clean up: remove work-arounds and polyfills

With WP 5.2 being the new minimum supported WP version, the polyfill for the `map_deep()` function is no longer needed.

Similarly, the bowing out for the term meta import (on WP < 4.4) is also no longer needed.

