### PR TITLE
PHP 8.1 | WXR_Parser_XML: fix autovivification on false

### DIFF
--- a/src/parsers/class-wxr-parser-xml.php
+++ b/src/parsers/class-wxr-parser-xml.php
@@ -118,6 +118,10 @@ class WXR_Parser_XML {
 		switch ( $tag ) {
 			case 'category':
 				if ( isset( $attr['domain'], $attr['nicename'] ) ) {
+					if ( false === $this->sub_data ) {
+						$this->sub_data = array();
+					}
+
 					$this->sub_data['domain'] = $attr['domain'];
 					$this->sub_data['slug']   = $attr['nicename'];
 				}
@@ -233,9 +237,17 @@ class WXR_Parser_XML {
 
 			default:
 				if ( $this->in_sub_tag ) {
+					if ( false === $this->sub_data ) {
+						$this->sub_data = array();
+					}
+
 					$this->sub_data[ $this->in_sub_tag ] = ! empty( $this->cdata ) ? $this->cdata : '';
 					$this->in_sub_tag                    = false;
 				} elseif ( $this->in_tag ) {
+					if ( false === $this->data ) {
+						$this->data = array();
+					}
+
 					$this->data[ $this->in_tag ] = ! empty( $this->cdata ) ? $this->cdata : '';
 					$this->in_tag                = false;
 				}


### PR DESCRIPTION
As of PHP 8.1, when a variable is set to `false` and subsequently is approached as an array to add/write to an array sub-key, a `Automatic conversion of false to array is deprecated` notice is thrown.

As the `WXR_Parser_XML::tag_close()` method in multiple places sets `$this->data` and `$this->sub-data` to `false`, this class is heavily subject to these notices and is causing 8 out of the 20 tests to fail.

By checking whether `$this->data`/`$this->sub_data` is `false` and turning it into an empty array before writing to it as if it were an array, these issues are fixed without BC-break.

Ref: https://wiki.php.net/rfc/autovivification_false


---

Note: the CI builds are broken (see PR #109). I'll happily rebase this PR once that PR has been merged.