### PR TITLE
PHP 8.1: fix a "passing null to non-nullable" deprecation

### DIFF
--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -275,5 +275,22 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertSame( '\o/ ¯\_(ツ)_/¯', $comments[0]->comment_content );
 	}
 
+	/**
+	 * Ensure no PHP 8.1 deprecation notice is thrown when a URL is passed without a path component.
+	 *
+	 * Note: this test doesn't test anything else of the functionality in the `WP_Import::fetch_remote_file()` method!
+	 */
+	public function test_fetch_remote_file_php81_deprecation() {
+		$importer = new WP_Import();
+		$result   = $importer->fetch_remote_file( 'https://example.com', array() );
+
+		$this->assertWPError( $result, 'Call to fetch_remote_file() did not return expected WP Error object' );
+		$this->assertSame(
+			'Sorry, this file type is not permitted for security reasons.',
+			$result->get_error_message(),
+			'The WP Error object did not contain the expected error'
+		);
+	}
+
 	// function test_menu_import
 }

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1060,7 +1060,11 @@ class WP_Import extends WP_Importer {
 	 */
 	function fetch_remote_file( $url, $post ) {
 		// Extract the file name from the URL.
-		$file_name = basename( parse_url( $url, PHP_URL_PATH ) );
+		$path      = parse_url( $url, PHP_URL_PATH );
+		$file_name = '';
+		if ( is_string( $path ) ) {
+			$file_name = basename( $path );
+		}
 
 		if ( ! $file_name ) {
 			$file_name = md5( $url );


### PR DESCRIPTION
Fixes PHP 8.1 `basename(): Passing null to parameter #1 ($path) of type string is deprecated` error due to the call to `parse_url()` returning `null` when the component requested does not exist in the passed URL, which in this case means a domain without trailing slash.

Includes a new unit test which would error out without this fix.

Note: the new test does not actually test the functioning of the `WP_Import::fetch_remote_file()` method in any significant way. It is only a regression test to prevent this particular PHP 8.1 deprecation notice from being reintroduced.