### PR TITLE
GH Actions: minor tweak to CS workflow

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,6 +39,8 @@ jobs:
 
       # Check the code-style consistency of the PHP files.
       - name: Check PHP code style
-        run: |
-          vendor/bin/phpcs --report-checkstyle=./phpcs-report.xml
-          cs2pr ./phpcs-report.xml
+        continue-on-error: true
+        run: vendor/bin/phpcs -- --report-full --report-checkstyle=./phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml


### PR DESCRIPTION
As per the [code sample in the CS2PR docs](https://github.com/staabm/annotate-pull-request-from-checkstyle#using-php_codesniffer), this minor change allows for displaying both the full report in the actual workflow, as well as displaying inline annotations on PRs.