### PR TITLE
Fix wp_insert_category fatal error

### DIFF
--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -423,7 +423,7 @@ class WP_Import extends WP_Importer {
 				'category_description' => wp_slash( $description ),
 			);
 
-			$id = wp_insert_category( $data );
+			$id = wp_insert_category( $data, true );
 			if ( ! is_wp_error( $id ) && $id > 0 ) {
 				if ( isset( $cat['term_id'] ) ) {
 					$this->processed_terms[ intval( $cat['term_id'] ) ] = $id;


### PR DESCRIPTION
Setting the second param to true so that it always returns a `WP_Error` as opposed to `0`.

Fixes #122 