### PR TITLE
Prepare a 0.8 release

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 5.6
+Tested up to: 6.0
 Requires PHP: 5.6
 Stable tag: 0.7.0
 License: GPLv2 or later
@@ -39,6 +39,9 @@ If you would prefer to do things manually then follow these instructions:
 1. Go to the Tools -> Import screen, click on WordPress
 
 == Changelog ==
+
+= 0.7.1 =
+ * Update compatibility tested-up-to to WordPress 6.0
 
 = 0.7 =
 * Update minimum WordPress requirement to 3.7 and ensure compatibility with PHP 7.4.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Tags: importer, wordpress
 Requires at least: 5.2
 Tested up to: 6.0
 Requires PHP: 5.6
-Stable tag: 0.7.0
+Stable tag: 0.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -41,13 +41,13 @@ If you would prefer to do things manually then follow these instructions:
 == Changelog ==
 
 = 0.8 =
- * Updated minimum WordPress requirement to 5.2
- * Updated minimum PHP requirement to 5.6
- * Updated compatibility tested-up-to to WordPress 6.0
- * PHP 8.0 & PHP 8.1 compatibility fixes
- * Improved Unit testing & automated testing
- * Regex Parser: ensure that blank lines in content are respected
- * Avoid a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
+* Updated minimum WordPress requirement to 5.2
+* Updated minimum PHP requirement to 5.6
+* Updated compatibility tested-up-to to WordPress 6.0
+* PHP 8.0 & PHP 8.1 compatibility fixes
+* Improved Unit testing & automated testing
+* Regex Parser: ensure that blank lines in content are respected
+* Avoid a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
 
 = 0.7 =
 * Update minimum WordPress requirement to 3.7 and ensure compatibility with PHP 7.4.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -40,8 +40,14 @@ If you would prefer to do things manually then follow these instructions:
 
 == Changelog ==
 
-= 0.7.1 =
- * Update compatibility tested-up-to to WordPress 6.0
+= 0.8 =
+ * Updated minimum WordPress requirement to 5.2
+ * Updated minimum PHP requirement to 5.6
+ * Updated compatibility tested-up-to to WordPress 6.0
+ * PHP 8.0 & PHP 8.1 compatibility fixes
+ * Improved Unit testing & automated testing
+ * Regex Parser: ensure that blank lines in content are respected
+ * Avoid a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
 
 = 0.7 =
 * Update minimum WordPress requirement to 3.7 and ensure compatibility with PHP 7.4.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -44,7 +44,7 @@ If you would prefer to do things manually then follow these instructions:
 * Update minimum WordPress requirement to 5.2.
 * Update minimum PHP requirement to 5.6.
 * Update compatibility tested-up-to to WordPress 6.0.
-* PHP 8.0 & PHP 8.1 compatibility fixes.
+* PHP 8.0, 8.1, and 8.2 compatibility fixes.
 * Fix a bug causing blank lines in content to be ignored when using the Regex Parser.
 * Fix a bug resulting in a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
 * Improved Unit testing & automated testing.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -41,13 +41,13 @@ If you would prefer to do things manually then follow these instructions:
 == Changelog ==
 
 = 0.8 =
-* Updated minimum WordPress requirement to 5.2
-* Updated minimum PHP requirement to 5.6
-* Updated compatibility tested-up-to to WordPress 6.0
-* PHP 8.0 & PHP 8.1 compatibility fixes
-* Improved Unit testing & automated testing
-* Regex Parser: ensure that blank lines in content are respected
-* Avoid a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
+* Update minimum WordPress requirement to 5.2.
+* Update minimum PHP requirement to 5.6.
+* Update compatibility tested-up-to to WordPress 6.0.
+* PHP 8.0 & PHP 8.1 compatibility fixes.
+* Fix a bug causing blank lines in content to be ignored when using the Regex Parser.
+* Fix a bug resulting in a PHP fatal error when IMPORT_DEBUG is enabled and a category creation error occurs.
+* Improved Unit testing & automated testing.
 
 = 0.7 =
 * Update minimum WordPress requirement to 3.7 and ensure compatibility with PHP 7.4.

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -6,7 +6,7 @@
  * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
  * Author:            wordpressdotorg
  * Author URI:        https://wordpress.org/
- * Version:           0.7
+ * Version:           0.8
  * Requires at least: 5.2
  * Requires PHP:      5.6
  * Text Domain:       wordpress-importer


### PR DESCRIPTION
It's been a year since the last release, and there's been some changes: https://github.com/WordPress/wordpress-importer/compare/0.7...master

As noted with #126, we should bump the tested-up-to, but might as well release these changes too.