### PR TITLE
PHP 8.2 | Explicitly declare all properties

### DIFF
--- a/src/parsers/class-wxr-parser-regex.php
+++ b/src/parsers/class-wxr-parser-regex.php
@@ -10,13 +10,14 @@
  * WXR Parser that uses regular expressions. Fallback for installs without an XML parser.
  */
 class WXR_Parser_Regex {
-	var $authors       = array();
-	var $posts         = array();
-	var $categories    = array();
-	var $tags          = array();
-	var $terms         = array();
-	var $base_url      = '';
-	var $base_blog_url = '';
+	public $authors       = array();
+	public $posts         = array();
+	public $categories    = array();
+	public $tags          = array();
+	public $terms         = array();
+	public $base_url      = '';
+	public $base_blog_url = '';
+	public $has_gzip;
 
 	function __construct() {
 		$this->has_gzip = is_callable( 'gzopen' );

--- a/src/parsers/class-wxr-parser-xml.php
+++ b/src/parsers/class-wxr-parser-xml.php
@@ -70,6 +70,8 @@ class WXR_Parser_XML {
 	public $term;
 	public $category;
 	public $tag;
+	public $base_url;
+	public $base_blog_url;
 
 	function parse( $file ) {
 		$this->wxr_version = false;

--- a/src/parsers/class-wxr-parser-xml.php
+++ b/src/parsers/class-wxr-parser-xml.php
@@ -10,7 +10,7 @@
  * WXR Parser that makes use of the XML Parser PHP extension.
  */
 class WXR_Parser_XML {
-	var $wp_tags     = array(
+	public $wp_tags     = array(
 		'wp:post_id',
 		'wp:post_date',
 		'wp:post_date_gmt',
@@ -43,7 +43,7 @@ class WXR_Parser_XML {
 		'wp:author_first_name',
 		'wp:author_last_name',
 	);
-	var $wp_sub_tags = array(
+	public $wp_sub_tags = array(
 		'wp:comment_id',
 		'wp:comment_author',
 		'wp:comment_author_email',
@@ -57,6 +57,19 @@ class WXR_Parser_XML {
 		'wp:comment_parent',
 		'wp:comment_user_id',
 	);
+
+	public $wxr_version;
+	public $in_post;
+	public $cdata;
+	public $data;
+	public $sub_data;
+	public $in_tag;
+	public $in_sub_tag;
+	public $authors;
+	public $posts;
+	public $term;
+	public $category;
+	public $tag;
 
 	function parse( $file ) {
 		$this->wxr_version = false;


### PR DESCRIPTION
Dynamic (non-explicitly declared) property usage is expected to be deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

### WXR_Parser_XML: explicitly declare all properties [1]

In this case, the `parse()` method explicitly sets each of those properties, so these fall in the "known property" category and should be explicitly declared.

### WXR_Parser_XML: explicitly declare all properties [2]

In this case, the `tag_close()` method explicitly sets each of those properties, so these fall in the "known property" category and should be explicitly declared.

### WXR_Parser_Regex: explicitly declare all properties

In this case, the `__construct()` method explicitly sets this property, so `$has_gzip` falls in the "known property" category and should be explicitly declared.
