### PR TITLE
GH Actions: add build against PHP 8.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
           - php: '8.1'
             wp: 'trunk'
             experimental: true
+          - php: '8.2'
+            wp: 'trunk'
+            experimental: true
           - php: '7.4'
             wp: 'trunk'
             experimental: true
@@ -102,25 +105,45 @@ jobs:
       - name: Set up WordPress
         run: phpunit/install.sh wordpress_test root '' 127.0.0.1:3306 ${{ matrix.wp }}
 
+      # Determine the type of Composer install which is needed.
+      # 1. WP 5.9 or higher - all PHPUnit versions needed are supported, use the most appropriate one.
+      # 2. WP 5.9 or higher with PHP 8.2 (RC) - not all dependencies of PHPUnit have declared PHP 8.2 compatibility, so needs ignore platform.
+      # 3. WP < 5.9 with PHP < 8.0 - PHPUnit 5 - 7 supported, use the most appropriate one.
+      # 4. WP < 5.9 with PHP 8.0 or higher - PHPUnit 5 - 7 supported, needs ignore platform reqs to install PHPUnit 7 for PHP >= 8.0.
+      - name: Determine the type of Composer install to use
+        id: composer_toggle
+        run: |
+          if [[ "${{ matrix.wp }}" =~ ^(trunk|latest|5\.9|[6789]\.[0-9])$ ]]; then
+            if [[ "${{ matrix.php }}" != "8.2" ]]; then
+              echo '::set-output name=TYPE::1'
+            else
+              echo '::set-output name=TYPE::2'
+            fi
+          elif [[ "${{ matrix.php }}" > "7.4" ]]; then
+            echo '::set-output name=TYPE::4'
+          else
+            echo '::set-output name=TYPE::3'
+          fi
+
       # Remove the PHPUnit requirement for WP 5.9 and higher in favour of letting the Polyfills manage it.
       # The Composer command will exit with error code 2 as the package is not removed, so ignore "failure" of this step.
       - name: Conditionally remove PHPUnit requirement
-        if: ${{ ( matrix.wp == 'trunk' || matrix.wp >= 5.9 ) && matrix.wp != 'latest' }}
+        if: ${{ steps.composer_toggle.outputs.TYPE == '1' || steps.composer_toggle.outputs.TYPE == '2' }}
         continue-on-error: true
         run: composer remove --dev phpunit/phpunit --no-update --no-interaction || true
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: Install Composer dependencies for PHP < 8.0
-        if: ${{ matrix.php < 8.0 || ( ( matrix.wp == 'trunk' || matrix.wp >= 5.9 ) && matrix.wp != 'latest' ) }}
+      - name: Install Composer dependencies - normal
+        if: ${{ steps.composer_toggle.outputs.TYPE == '1' || steps.composer_toggle.outputs.TYPE == '3' }}
         uses: "ramsey/composer-install@v2"
 
       # For PHP 8.0 and above on WP 5.2 - 5.8, we need to install with ignore platform reqs as not all dependencies allow it.
-      - name: Install Composer dependencies for PHP >= 8.0
-        if: ${{ matrix.php >= 8.0 && ( matrix.wp == 'latest' || ( matrix.wp != 'trunk' && matrix.wp < 5.9 ) ) }}
+      - name: Install Composer dependencies with ignore platform reqs
+        if: ${{ steps.composer_toggle.outputs.TYPE == '2' || steps.composer_toggle.outputs.TYPE == '4' }}
         uses: "ramsey/composer-install@v2"
         with:
-          composer-options: --ignore-platform-reqs
+          composer-options: --ignore-platform-req=php
 
       - name: Run the unit tests - single site
         run: vendor/bin/phpunit


### PR DESCRIPTION
Now PR #128 has been merged, let's enable a GH Actions build against PHP 8.2.

While the build - for now - won't pass due to a PHP 8.1 issue with WP Core, I have done a test run which [didn't convert deprecations to exceptions](https://github.com/WordPress/wordpress-importer/runs/7320373532?check_suite_focus=true), and that run shows that the tests for the plugin itself will now pass.

Note: there are still plenty of deprecations coming from WP Core itself. Those are outside the scope of this ticket and not solvable here anyway.
The following WP Core tickets are open to address those:
* https://core.trac.wordpress.org/ticket/56033
* https://core.trac.wordpress.org/ticket/56034

~~Also note there is currently an issue with the GD extension on PHP 8.2. This - again - is outside the scope of this ticket. This is most likely an issue with one of the underlying libraries used by the `setup-php` action runner and is expected to be a temporary hickup.~~