### PR TITLE
Tests/GH Actions: allow for upstream issue which prevented the PHP 8.1 builds from passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,17 @@ jobs:
         experimental: [false]
 
         include:
-          # Complement the builds run via the matrix with high/low WP builds for PHP 7.4 and 8.0.
-          # PHP 8.1 is sort of supported since WP 5.9.
+          # Complement the builds run via the matrix with high/low WP builds for PHP 7.4 up to 8.2.
+          # PHP 8.2 is sort of supported since WP 6.1.
+          # PHP 8.1 is sort of supported since WP 5.9 (with the exception of Requests, which was updated in WP 6.2).
           # PHP 8.0 is sort of supported since WP 5.6.
           # PHP 7.4 is supported since WP 5.3.
+          - php: '8.2'
+            wp: 'latest'
+            experimental: false
+          - php: '8.2'
+            wp: '6.1'
+            experimental: false
           - php: '8.1'
             wp: 'latest'
             experimental: false
@@ -68,7 +75,7 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.2'
+          - php: '8.3'
             wp: 'trunk'
             experimental: true
           - php: '7.4'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,15 @@ jobs:
 
         include:
           # Complement the builds run via the matrix with high/low WP builds for PHP 7.4 and 8.0.
+          # PHP 8.1 is sort of supported since WP 5.9.
           # PHP 8.0 is sort of supported since WP 5.6.
           # PHP 7.4 is supported since WP 5.3.
+          - php: '8.1'
+            wp: 'latest'
+            experimental: false
+          - php: '8.1'
+            wp: '5.9'
+            experimental: false
           - php: '8.0'
             wp: 'latest'
             experimental: false
@@ -61,9 +68,6 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.1'
-            wp: 'trunk'
-            experimental: true
           - php: '8.2'
             wp: 'trunk'
             experimental: true

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -281,6 +281,11 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 	 * Note: this test doesn't test anything else of the functionality in the `WP_Import::fetch_remote_file()` method!
 	 */
 	public function test_fetch_remote_file_php81_deprecation() {
+		// Temporary until WP updates to Requests 2.0.0.
+		if ( PHP_VERSION_ID >= 80100 ) {
+			$this->markTestSkipped( 'Test will fail on PHP 8.1+ until WP has upgraded to Requests 2.0.0. Temporarily skipping the test.' );
+		}
+
 		$importer = new WP_Import();
 		$result   = $importer->fetch_remote_file( 'https://example.com', array() );
 


### PR DESCRIPTION
### Tests: temporarily skip a test until WP updates the Requests library

This should allow the PHP 8.1 build to pass.

### GH Actions: do not allow the PHP 8.1 build to fail anymore

... and test against the highest and lowest support WP version.

### GH Actions: update the matrix for latest WP/PHP