### PR TITLE
GH Actions: tweak setup-php

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
-          # The PHP 5.6 and 7.0 images don't include mysql[i] by default.
-          extensions: mysqli
 
       - name: Set up WordPress
         run: phpunit/install.sh wordpress_test root '' 127.0.0.1:3306 ${{ matrix.wp }}


### PR DESCRIPTION
1. Now Ubuntu 20 is the current image, `mysqli` is available by default, including on PHP 5.6 and 7.0, so no need to require this specifically.
2. Setup-PHP uses the production `php.ini` by default, which means that the error reporting related settings are not optimal for test runs, Fixed by explicitly setting the ini values for select config settings.