### PR TITLE
GH Actions: adjust the workflow triggers

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -6,13 +6,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
This removes the `paths-ignore` configuration.

While running the builds on commits which only have changes to the `md` or `txt` files has no actual benefit, as those files do not influence the build results, not running the builds prevents merging PRs as branch protection with required build statuses has been turned on.

This fixes that conundrum.