### PR TITLE
Add support for WordPress 6.2

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,9 +3,9 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 6.1
+Tested up to: 6.2
 Requires PHP: 5.6
-Stable tag: 0.8
+Stable tag: 0.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,11 @@ If you would prefer to do things manually then follow these instructions:
 1. Go to the Tools -> Import screen, click on WordPress
 
 == Changelog ==
+
+= 0.9 =
+
+* Update compatibility tested-up-to to WordPress 6.2.
+* Update paths to build status badges.
 
 = 0.8 =
 * Update minimum WordPress requirement to 5.2.

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -6,7 +6,7 @@
  * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
  * Author:            wordpressdotorg
  * Author URI:        https://wordpress.org/
- * Version:           0.8
+ * Version:           0.9
  * Requires at least: 5.2
  * Requires PHP:      5.6
  * Text Domain:       wordpress-importer

--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: WordPress Importer Git loader
- * Version: 0.8
+ * Version: 0.9
  */
 
 // This file is included purely for those using Git and checking out directly into wp-content/plugins/wordpress-importer/


### PR DESCRIPTION
This PR adds support for WordPress 6.2 and upgrades the plugin to 0.9.

- Tested with WordPress 6.2
- Tested with PHP 5.6, PHP 7.4.33, PHP 8.0

How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "5.6",
  "plugins": ["./wordpress-importer"]
}
``` 
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=wordpress` and perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors