### PR TITLE
Update workflow actions to use v3 to align Node 16

### DIFF
--- a/.github/workflows/asset-readme.yml
+++ b/.github/workflows/asset-readme.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable


### PR DESCRIPTION
Previous deployment was failed due to the [actions](https://github.com/WordPress/wordpress-importer/actions/runs/4636698907). This PR updates the `asset-readme.yml` to use `actions/checkout@v3` to align with Node 16, see more on [https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)