### PR TITLE
Fix error workflow actions for assets

### DIFF
--- a/.github/workflows/asset-readme.yml
+++ b/.github/workflows/asset-readme.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
+      uses: 10up/action-wordpress-plugin-asset-update@develop
       env:
         README_NAME: src/readme.txt
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
This PR fixes the error assets workflow by applying the develop version of `10up/action-wordpress-plugin-asset-update@develop`.