### PR TITLE
Update version to 0.8.1

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Tags: importer, wordpress
 Requires at least: 5.2
 Tested up to: 6.2
 Requires PHP: 5.6
-Stable tag: 0.9
+Stable tag: 0.8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,7 +40,7 @@ If you would prefer to do things manually then follow these instructions:
 
 == Changelog ==
 
-= 0.9 =
+= 0.8.1 =
 
 * Update compatibility tested-up-to to WordPress 6.2.
 * Update paths to build status badges.

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -6,7 +6,7 @@
  * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
  * Author:            wordpressdotorg
  * Author URI:        https://wordpress.org/
- * Version:           0.9
+ * Version:           0.8.1
  * Requires at least: 5.2
  * Requires PHP:      5.6
  * Text Domain:       wordpress-importer

--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: WordPress Importer Git loader
- * Version: 0.9
+ * Version: 0.8.1
  */
 
 // This file is included purely for those using Git and checking out directly into wp-content/plugins/wordpress-importer/


### PR DESCRIPTION
Based on the suggestion [here](https://github.com/WordPress/wordpress-importer/pull/146#issuecomment-1500251181) it'll be better for us to use version 0.8.1 instead of 0.9