### PR TITLE
Update tested up to label and test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
           - php: '7.0'
             wp: '5.8'
             experimental: false
+          - php: '7.0'
+            wp: '6.3'
+            experimental: false
 
           # Experimental builds. These are allowed to fail.
           - php: '8.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,10 @@ jobs:
             wp: '5.3'
             experimental: false
           - php: '5.6'
-            wp: '5.2'
+            wp: '5.5'
             experimental: false
           - php: '5.6'
-            wp: '5.5'
+            wp: '5.2'
             experimental: false
           - php: '7.2'
             wp: '5.7'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # Notes regarding supported versions in WP:
         # The base matrix only contains the PHP versions which are supported on all supported WP versions.
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        php: ['7.0', '7.1', '7.2', '7.3']
         wp: ['latest', '5.2']
         experimental: [false]
 
@@ -49,6 +49,9 @@ jobs:
           # Complement the builds run via the matrix with some additional builds against specific WP versions.
           - php: '7.3'
             wp: '5.3'
+            experimental: false
+          - php: '5.6'
+            wp: '5.2'
             experimental: false
           - php: '5.6'
             wp: '5.5'

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 6.2
+Tested up to: 6.4.2
 Requires PHP: 5.6
 Stable tag: 0.8.1
 License: GPLv2 or later


### PR DESCRIPTION
- This PR test for WordPress 6.4.2 with PHP 7.0, 7.4 and 8.0.
- Since latest WordPress is not supporting PHP 5.6 anymore, we also need to modify `test.yml`

How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "7.0",
  "plugins": ["./wordpress-importer"]
}
``` 
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=wordpress` and perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors