### PR TITLE
Bump version up to 0.8.2

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -5,7 +5,7 @@ Tags: importer, wordpress
 Requires at least: 5.2
 Tested up to: 6.4.2
 Requires PHP: 5.6
-Stable tag: 0.8.1
+Stable tag: 0.8.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,6 +39,12 @@ If you would prefer to do things manually then follow these instructions:
 1. Go to the Tools -> Import screen, click on WordPress
 
 == Changelog ==
+
+= 0.8.2 =
+
+* Update compatibility tested-up-to to WordPress 6.4.2.
+* Update doc URL references.
+* Adjust workflow triggers.
 
 = 0.8.1 =
 

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -6,7 +6,7 @@
  * Description:       Import posts, pages, comments, custom fields, categories, tags and more from a WordPress export file.
  * Author:            wordpressdotorg
  * Author URI:        https://wordpress.org/
- * Version:           0.8.1
+ * Version:           0.8.2
  * Requires at least: 5.2
  * Requires PHP:      5.6
  * Text Domain:       wordpress-importer

--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: WordPress Importer Git loader
- * Version: 0.8.1
+ * Version: 0.8.2
  */
 
 // This file is included purely for those using Git and checking out directly into wp-content/plugins/wordpress-importer/


### PR DESCRIPTION
Bumping version up to include latest changes:

* Update compatibility tested-up-to to WordPress 6.4.2.
* Update doc URL references.
* Adjust workflow triggers.