### PR TITLE
GH Actions: update the matrix for latest WP/PHP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,31 +24,55 @@ jobs:
         experimental: [false]
 
         include:
-          # Complement the builds run via the matrix with high/low WP builds for PHP 7.4 and 8.0.
-          # PHP 8.0 is sort of supported since WP 5.6.
-          # PHP 7.4 is supported since WP 5.3.
+          # Complement the builds run via the matrix with high/low WP builds for PHP 5.6 and PHP 7.4 up to 8.3.
+          # PHP 8.3 is beta-supported since WP 6.4.
+          - php: '8.3'
+            wp: 'latest'
+            experimental: false
+          - php: '8.3'
+            wp: '6.4'
+            experimental: false
+          # PHP 8.2 is beta-supported since WP 6.1 and Requests was updated in WP 6.2.
+          # That means that WP 6.2 is the earliest WP version which can be used with PHP 8.1 for this plugin.
+          - php: '8.2'
+            wp: 'latest'
+            experimental: false
+          - php: '8.2'
+            wp: '6.2'
+            experimental: false
+          # PHP 8.1 is beta-supported since WP 5.9 and Requests was updated in WP 6.2.
+          # That means that WP 6.2 is the earliest WP version which can be used with PHP 8.1 for this plugin.
+          - php: '8.1'
+            wp: 'latest'
+            experimental: false
+          - php: '8.1'
+            wp: '6.2'
+            experimental: false
+          # PHP 8.0 is beta-supported since WP 5.6.
           - php: '8.0'
             wp: 'latest'
             experimental: false
           - php: '8.0'
             wp: '5.6'
             experimental: false
+          # PHP 7.4 is supported since WP 5.3.
           - php: '7.4'
             wp: 'latest'
             experimental: false
           - php: '7.4'
             wp: '5.4'
             experimental: false
-
-          # Complement the builds run via the matrix with some additional builds against specific WP versions.
-          - php: '7.3'
-            wp: '5.3'
-            experimental: false
+          # PHP 5.6 was supported up to WP 6.2.
           - php: '5.6'
-            wp: '5.5'
+            wp: '6.2'
             experimental: false
           - php: '5.6'
             wp: '5.2'
+            experimental: false
+
+          # Complement the builds run via the matrix with some additional builds against specific WP versions.
+          - php: '7.3'
+            wp: '6.0'
             experimental: false
           - php: '7.2'
             wp: '5.7'
@@ -56,17 +80,11 @@ jobs:
           - php: '7.0'
             wp: '5.8'
             experimental: false
-          - php: '7.0'
+          - php: '7.4'
             wp: '6.3'
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.1'
-            wp: 'trunk'
-            experimental: true
-          - php: '8.2'
-            wp: 'trunk'
-            experimental: true
           - php: '7.4'
             wp: 'trunk'
             experimental: true


### PR DESCRIPTION
This commit:
* Adds a proper set of builds against PHP 8.1, 8.2 and PHP 8.3 against low/high WP versions supported for those PHP versions as those PHP versions have been released and should be supported.
* Removes the "experimental" builds against PHP 8.1 and 8.2 as those PHP versions have been released and should be supported.
* Moves the builds against PHP 5.6 from the "complementary" builds section to the "PHP version support" section.
* Moves some comments around to make it more straight forward to understand how this matrix should be read and updated.

I've verified that all (nearly) WP versions between the lowest and the highest supported version now have at least one build.