### PR TITLE
Update call to post_exists to include post_type in the query

### DIFF
--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -656,7 +656,7 @@ class WP_Import extends WP_Importer {
 
 			$post_type_object = get_post_type_object( $post['post_type'] );
 
-			$post_exists = post_exists( $post['post_title'], '', $post['post_date'] );
+			$post_exists = post_exists( $post['post_title'], '', $post['post_date'], $post['post_type'] );
 
 			/**
 			* Filter ID of the existing post corresponding to post currently importing.


### PR DESCRIPTION
During the post import we check whether the post already exists using [post_exists](https://developer.wordpress.org/reference/functions/post_exists/).

The query currently utilises post title and date parameters, which will run through all the posts to try and find a match.

In cases where we have a large number of posts this query can time out and the import fail.

Passing the `post_type` to `post_exists` function allows us to use the `type_status_date` key, which significantly drops the number of rows examined and the overall query time in certain instances.

This change would also fix some edge case scenarios with posts across post types having the same title and date.

Issue link: https://github.com/WordPress/wordpress-importer/issues/162