### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot configuration.
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
I noticed a number of action runners used are out of date. Most updates are related to the Node version the action runners use under the hood updating to Node 20. Not having those updates will become problematic soonish when GHA drops support for Node 16.

So, instead of manually updating the workflows, I'm proposing enabling Dependabot to submit updates for the GHA runners. This should take care of it via Dependabot opening PRs to do the updates.