### PR TITLE
Tests_Import_Parser::test_blank_lines_in_content(): minor test fix

### DIFF
--- a/phpunit/tests/parser.php
+++ b/phpunit/tests/parser.php
@@ -236,7 +236,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 			$result  = $parser->parse( $file );
 
 			// Check the number of new lines characters
-			$this->assertSame( 3, substr_count( $result['posts'][0]['post_content'], PHP_EOL ), $message );
+			$this->assertSame( 3, substr_count( $result['posts'][0]['post_content'], "\n" ), $message );
 		}
 	}
 


### PR DESCRIPTION
Depending on how a git repo is cloned, files may have *nix line endings or Windows line endings. Now, as this test uses a file based fixture, this has an impact on the tests.

As things are, the test basically assumes that `core.autocrlf=true` (change line endings based on the OS) is used, while that is an assumption which cannot be made.

This can lead to confusion for contributors when they are confronted by an inexplicably failing test.

As the Windows line ending `\r\n` includes the *nix line ending `\n` anyway, changing the test to just check for the count of the `\n` characters maintains the value of the test, while preventing test failures for contributors who run the test on Windows and check out with `core.autocrlf=input`.