### PR TITLE
Start using WordPressCS 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "wp-coding-standards/wpcs": "^2.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "wp-coding-standards/wpcs": "^3.1",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "yoast/phpunit-polyfills": "^1.0.1",
         "phpunit/phpunit": "^5.7.21 || ^6.5 || ^7.5"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,8 +31,9 @@
 	-->
 
 	<rule ref="WordPress-Core">
-		<exclude name="WordPress.PHP.StrictComparisons"/>
+		<exclude name="Universal.Operators.StrictComparisons"/>
 		<exclude name="WordPress.WP.I18n"/>
+		<exclude name="Modernize.FunctionCalls.Dirname.Nested"/><!-- Needs PHP 7.0 minimum. -->
 	</rule>
 	<rule ref="WordPress.Files.FileName">
 		<exclude-pattern>*/phpunit/tests/*\.php$</exclude-pattern>

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -24,7 +24,7 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 
 define( 'WP_LOAD_IMPORTERS', true );
 
-define( 'DIR_TESTDATA_WP_IMPORTER', dirname( __FILE__ ) . '/data' );
+define( 'DIR_TESTDATA_WP_IMPORTER', __DIR__ . '/data' );
 
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
@@ -34,7 +34,7 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_importer() {
 	if ( ! class_exists( 'WP_Import' ) ) {
-		require dirname( dirname( __FILE__ ) ) . '/src/wordpress-importer.php';
+		require dirname( __DIR__ ) . '/src/wordpress-importer.php';
 	}
 }
 tests_add_filter( 'plugins_loaded', '_manually_load_importer' );

--- a/phpunit/tests/base.php
+++ b/phpunit/tests/base.php
@@ -42,7 +42,7 @@ abstract class WP_Import_UnitTestCase extends WP_UnitTestCase {
 				$new[ $i ] = $map;
 			}
 
-			$i++;
+			++$i;
 		}
 
 		$_POST = array(

--- a/phpunit/tests/comment-meta.php
+++ b/phpunit/tests/comment-meta.php
@@ -7,7 +7,7 @@ require_once dirname( __FILE__ ) . '/base.php';
  * @group comment-meta
  */
 class Tests_Import_Comment_Meta extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -19,7 +19,7 @@ class Tests_Import_Comment_Meta extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_serialized_comment_meta() {
+	public function test_serialized_comment_meta() {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-comment-meta.xml', array( 'admin' => 'admin' ) );
 
 		$expected_string = '¯\_(ツ)_/¯';

--- a/phpunit/tests/comment-meta.php
+++ b/phpunit/tests/comment-meta.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/base.php';
+require_once __DIR__ . '/base.php';
 
 /**
  * @group import

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -6,7 +6,7 @@ require_once dirname( __FILE__ ) . '/base.php';
  * @group import
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -27,13 +27,13 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		remove_filter( 'import_allow_create_users', '__return_true' );
 
 		parent::tear_down();
 	}
 
-	function test_small_import() {
+	public function test_small_import() {
 		global $wpdb;
 
 		$authors = array(
@@ -201,7 +201,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertCount( 1, $cats );
 	}
 
-	function test_double_import() {
+	public function test_double_import() {
 		$authors = array(
 			'admin'  => false,
 			'editor' => false,

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/base.php';
+require_once __DIR__ . '/base.php';
 
 /**
  * @group import

--- a/phpunit/tests/parser.php
+++ b/phpunit/tests/parser.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/base.php';
+require_once __DIR__ . '/base.php';
 
 /**
  * @group import

--- a/phpunit/tests/parser.php
+++ b/phpunit/tests/parser.php
@@ -6,7 +6,7 @@ require_once dirname( __FILE__ ) . '/base.php';
  * @group import
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -19,7 +19,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 	}
 
-	function test_malformed_wxr() {
+	public function test_malformed_wxr() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/malformed.xml';
 
 		// Regex based parser cannot detect malformed XML.
@@ -31,7 +31,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_invalid_wxr() {
+	public function test_invalid_wxr() {
 		$f1 = DIR_TESTDATA_WP_IMPORTER . '/missing-version-tag.xml';
 		$f2 = DIR_TESTDATA_WP_IMPORTER . '/invalid-version-tag.xml';
 
@@ -45,7 +45,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_wxr_version_1_1() {
+	public function test_wxr_version_1_1() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/valid-wxr-1.1.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -138,7 +138,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_wxr_version_1_0() {
+	public function test_wxr_version_1_0() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/valid-wxr-1.0.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -227,7 +227,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	}
 
 	// Test that all parsers preserve blank lines in content
-	function test_blank_lines_in_content() {
+	public function test_blank_lines_in_content() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/post-content-blank-lines.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -241,7 +241,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	}
 
 	// Tests that each parser detects the same number of terms.
-	function test_varied_taxonomy_term_spacing() {
+	public function test_varied_taxonomy_term_spacing() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/term-formats.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -269,7 +269,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/15203
 	 */
-	function test_escaped_cdata_closing_sequence() {
+	public function test_escaped_cdata_closing_sequence() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/crazy-cdata-escaped.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -302,7 +302,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	 * Ensure that the regex parser can still parse invalid CDATA blocks (i.e. those
 	 * with "]]>" unescaped within a CDATA section).
 	 */
-	function test_unescaped_cdata_closing_sequence() {
+	public function test_unescaped_cdata_closing_sequence() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/crazy-cdata.xml';
 
 		$parser = new WXR_Parser_Regex;
@@ -331,7 +331,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	/**
 	 * @group term-meta
 	 */
-	function test_term_meta_parsing() {
+	public function test_term_meta_parsing() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/test-serialized-term-meta.xml';
 
 		$expected_meta = array(
@@ -374,7 +374,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	/**
 	 * @group comment-meta
 	 */
-	function test_comment_meta_parsing() {
+	public function test_comment_meta_parsing() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/test-serialized-comment-meta.xml';
 
 		$expected_meta = array(

--- a/phpunit/tests/parser.php
+++ b/phpunit/tests/parser.php
@@ -24,7 +24,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		// Regex based parser cannot detect malformed XML.
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML' ) as $p ) {
-			$parser = new $p;
+			$parser = new $p();
 			$result = $parser->parse( $file );
 			$this->assertWPError( $result );
 			$this->assertSame( 'There was an error when reading this WXR file', $result->get_error_message() );
@@ -37,7 +37,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			foreach ( array( $f1, $f2 ) as $file ) {
-				$parser = new $p;
+				$parser = new $p();
 				$result = $parser->parse( $file );
 				$this->assertWPError( $result );
 				$this->assertSame( 'This does not appear to be a WXR file, missing/invalid WXR version number', $result->get_error_message() );
@@ -50,7 +50,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = $p . ' failed';
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			$this->assertIsArray( $result, $message );
@@ -143,7 +143,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = $p . ' failed';
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			$this->assertIsArray( $result, $message );
@@ -232,7 +232,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = $p . ' failed and is missing blank lines';
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			// Check the number of new lines characters
@@ -246,7 +246,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = $p . ' failed';
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			$this->assertIsArray( $result, $message );
@@ -274,7 +274,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = 'Parser ' . $p;
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			$post = $result['posts'][0];
@@ -305,7 +305,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	public function test_unescaped_cdata_closing_sequence() {
 		$file = DIR_TESTDATA_WP_IMPORTER . '/crazy-cdata.xml';
 
-		$parser = new WXR_Parser_Regex;
+		$parser = new WXR_Parser_Regex();
 		$result = $parser->parse( $file );
 
 		$post = $result['posts'][0];
@@ -347,7 +347,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = 'Parser ' . $p;
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			$this->assertCount( 1, $result['categories'], $message );
@@ -390,7 +390,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
 			$message = 'Parser ' . $p;
-			$parser  = new $p;
+			$parser  = new $p();
 			$result  = $parser->parse( $file );
 
 			$this->assertCount( 1, $result['posts'], $message );

--- a/phpunit/tests/parser.php
+++ b/phpunit/tests/parser.php
@@ -16,7 +16,6 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
 			define( 'WP_LOAD_IMPORTERS', true );
 		}
-
 	}
 
 	public function test_malformed_wxr() {

--- a/phpunit/tests/postmeta.php
+++ b/phpunit/tests/postmeta.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/base.php';
+require_once __DIR__ . '/base.php';
 
 /**
  * @group import

--- a/phpunit/tests/postmeta.php
+++ b/phpunit/tests/postmeta.php
@@ -7,7 +7,7 @@ require_once dirname( __FILE__ ) . '/base.php';
  * @group post-meta
  */
 class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -20,14 +20,14 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 
 	}
 
-	function test_serialized_postmeta_no_cdata() {
+	public function test_serialized_postmeta_no_cdata() {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-postmeta-no-cdata.xml', array( 'johncoswell' => 'john' ) );
 		$expected['special_post_title'] = 'A special title';
 		$expected['is_calendar']        = '';
 		$this->assertSame( $expected, get_post_meta( 122, 'post-options', true ) );
 	}
 
-	function test_utw_postmeta() {
+	public function test_utw_postmeta() {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-utw-post-meta-import.xml', array( 'johncoswell' => 'john' ) );
 
 		$classy      = new StdClass();
@@ -76,7 +76,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	/**
 	 * @ticket 9633
 	 */
-	function test_serialized_postmeta_with_cdata() {
+	public function test_serialized_postmeta_with_cdata() {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-postmeta-with-cdata.xml', array( 'johncoswell' => 'johncoswell' ) );
 
 		// HTML in the CDATA should work with old WordPress version.
@@ -90,7 +90,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	/**
 	 * @ticket 11574
 	 */
-	function test_serialized_postmeta_with_evil_stuff_in_cdata() {
+	public function test_serialized_postmeta_with_evil_stuff_in_cdata() {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-postmeta-with-cdata.xml', array( 'johncoswell' => 'johncoswell' ) );
 		// Evil content in the CDATA.
 		$this->assertSame( '<wp:meta_value>evil</wp:meta_value>', get_post_meta( 10, 'evil', true ) );
@@ -99,7 +99,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	/**
 	 * @ticket 11574
 	 */
-	function test_serialized_postmeta_with_slashes() {
+	public function test_serialized_postmeta_with_slashes() {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-postmeta-with-cdata.xml', array( 'johncoswell' => 'johncoswell' ) );
 
 		$expected_integer      = '1';

--- a/phpunit/tests/postmeta.php
+++ b/phpunit/tests/postmeta.php
@@ -17,7 +17,6 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 		if ( ! defined( 'WP_LOAD_IMPORTERS' ) ) {
 			define( 'WP_LOAD_IMPORTERS', true );
 		}
-
 	}
 
 	public function test_serialized_postmeta_no_cdata() {

--- a/phpunit/tests/term-meta.php
+++ b/phpunit/tests/term-meta.php
@@ -7,7 +7,7 @@ require_once dirname( __FILE__ ) . '/base.php';
  * @group term-meta
  */
 class Tests_Import_Term_Meta extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -19,7 +19,7 @@ class Tests_Import_Term_Meta extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_serialized_term_meta() {
+	public function test_serialized_term_meta() {
 		register_taxonomy( 'custom_taxonomy', array( 'post' ) );
 
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/test-serialized-term-meta.xml', array( 'admin' => 'admin' ) );

--- a/phpunit/tests/term-meta.php
+++ b/phpunit/tests/term-meta.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once dirname( __FILE__ ) . '/base.php';
+require_once __DIR__ . '/base.php';
 
 /**
  * @group import

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -10,32 +10,32 @@
  * WordPress importer class.
  */
 class WP_Import extends WP_Importer {
-	var $max_wxr_version = 1.2; // max. supported WXR version
+	public $max_wxr_version = 1.2; // max. supported WXR version
 
-	var $id; // WXR attachment ID
+	public $id; // WXR attachment ID
 
 	// information to import from WXR file
-	var $version;
-	var $authors    = array();
-	var $posts      = array();
-	var $terms      = array();
-	var $categories = array();
-	var $tags       = array();
-	var $base_url   = '';
+	public $version;
+	public $authors    = array();
+	public $posts      = array();
+	public $terms      = array();
+	public $categories = array();
+	public $tags       = array();
+	public $base_url   = '';
 
 	// mappings from old information to new
-	var $processed_authors    = array();
-	var $author_mapping       = array();
-	var $processed_terms      = array();
-	var $processed_posts      = array();
-	var $post_orphans         = array();
-	var $processed_menu_items = array();
-	var $menu_item_orphans    = array();
-	var $missing_menu_items   = array();
+	public $processed_authors    = array();
+	public $author_mapping       = array();
+	public $processed_terms      = array();
+	public $processed_posts      = array();
+	public $post_orphans         = array();
+	public $processed_menu_items = array();
+	public $menu_item_orphans    = array();
+	public $missing_menu_items   = array();
 
-	var $fetch_attachments = false;
-	var $url_remap         = array();
-	var $featured_images   = array();
+	public $fetch_attachments = false;
+	public $url_remap         = array();
+	public $featured_images   = array();
 
 	/**
 	 * Registered callback function for the WordPress Importer

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -859,7 +859,7 @@ class WP_Import extends WP_Importer {
 							add_comment_meta( $inserted_comments[ $key ], wp_slash( $meta['key'] ), wp_slash_strings_only( $value ) );
 						}
 
-						$num_comments++;
+						++$num_comments;
 					}
 				}
 				unset( $newcomments, $inserted_comments, $post['comments'] );

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -42,7 +42,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * Manages the three separate stages of the WXR import process
 	 */
-	function dispatch() {
+	public function dispatch() {
 		$this->header();
 
 		$step = empty( $_GET['step'] ) ? 0 : (int) $_GET['step'];
@@ -74,7 +74,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @param string $file Path to the WXR file for importing
 	 */
-	function import( $file ) {
+	public function import( $file ) {
 		add_filter( 'import_post_meta_key', array( $this, 'is_valid_meta_key' ) );
 		add_filter( 'http_request_timeout', array( &$this, 'bump_request_timeout' ) );
 
@@ -102,7 +102,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @param string $file Path to the WXR file for importing
 	 */
-	function import_start( $file ) {
+	public function import_start( $file ) {
 		if ( ! is_file( $file ) ) {
 			echo '<p><strong>' . __( 'Sorry, there has been an error.', 'wordpress-importer' ) . '</strong><br />';
 			echo __( 'The file does not exist, please try again.', 'wordpress-importer' ) . '</p>';
@@ -136,7 +136,7 @@ class WP_Import extends WP_Importer {
 	/**
 	 * Performs post-import cleanup of files and the cache
 	 */
-	function import_end() {
+	public function import_end() {
 		wp_import_cleanup( $this->id );
 
 		wp_cache_flush();
@@ -160,7 +160,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @return bool False if error uploading or invalid file, true otherwise
 	 */
-	function handle_upload() {
+	public function handle_upload() {
 		$file = wp_import_handle_upload();
 
 		if ( isset( $file['error'] ) ) {
@@ -202,7 +202,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @param array $import_data Data returned by a WXR parser
 	 */
-	function get_authors_from_import( $import_data ) {
+	public function get_authors_from_import( $import_data ) {
 		if ( ! empty( $import_data['authors'] ) ) {
 			$this->authors = $import_data['authors'];
 			// no author information, grab it from the posts
@@ -229,7 +229,7 @@ class WP_Import extends WP_Importer {
 	 * Display pre-import options, author importing/mapping and option to
 	 * fetch attachments
 	 */
-	function import_options() {
+	public function import_options() {
 		$j = 0;
 		// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect
 		?>
@@ -271,7 +271,7 @@ class WP_Import extends WP_Importer {
 	 * @param int $n Index for each author in the form
 	 * @param array $author Author information, e.g. login, display name, email
 	 */
-	function author_select( $n, $author ) {
+	public function author_select( $n, $author ) {
 		_e( 'Import author:', 'wordpress-importer' );
 		echo ' <strong>' . esc_html( $author['author_display_name'] );
 		if ( '1.0' != $this->version ) {
@@ -329,7 +329,7 @@ class WP_Import extends WP_Importer {
 	 * in import options form. Can map to an existing user, create a new user
 	 * or falls back to the current user in case of error with either of the previous
 	 */
-	function get_author_mapping() {
+	public function get_author_mapping() {
 		if ( ! isset( $_POST['imported_authors'] ) ) {
 			return;
 		}
@@ -393,7 +393,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * Doesn't create a new category if its slug already exists
 	 */
-	function process_categories() {
+	public function process_categories() {
 		$this->categories = apply_filters( 'wp_import_categories', $this->categories );
 
 		if ( empty( $this->categories ) ) {
@@ -448,7 +448,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * Doesn't create a tag if its slug already exists
 	 */
-	function process_tags() {
+	public function process_tags() {
 		$this->tags = apply_filters( 'wp_import_tags', $this->tags );
 
 		if ( empty( $this->tags ) ) {
@@ -499,7 +499,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * Doesn't create a term its slug already exists
 	 */
-	function process_terms() {
+	public function process_terms() {
 		$this->terms = apply_filters( 'wp_import_terms', $this->terms );
 
 		if ( empty( $this->terms ) ) {
@@ -624,7 +624,7 @@ class WP_Import extends WP_Importer {
 	 * is already noted as imported or a post with the same title and date already exists.
 	 * Note that new/updated terms, comments and meta are imported for the last of the above.
 	 */
-	function process_posts() {
+	public function process_posts() {
 		$this->posts = apply_filters( 'wp_import_posts', $this->posts );
 
 		foreach ( $this->posts as $post ) {
@@ -917,7 +917,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @param array $item Menu item details from WXR file
 	 */
-	function process_menu_item( $item ) {
+	public function process_menu_item( $item ) {
 		// skip draft, orphaned menu items
 		if ( 'draft' == $item['status'] ) {
 			return;
@@ -1006,7 +1006,7 @@ class WP_Import extends WP_Importer {
 	 * @param string $url URL to fetch attachment from
 	 * @return int|WP_Error Post ID on success, WP_Error otherwise
 	 */
-	function process_attachment( $post, $url ) {
+	public function process_attachment( $post, $url ) {
 		if ( ! $this->fetch_attachments ) {
 			return new WP_Error(
 				'attachment_processing_error',
@@ -1058,7 +1058,7 @@ class WP_Import extends WP_Importer {
 	 * @param array $post Attachment details
 	 * @return array|WP_Error Local file location details on success, WP_Error otherwise
 	 */
-	function fetch_remote_file( $url, $post ) {
+	public function fetch_remote_file( $url, $post ) {
 		// Extract the file name from the URL.
 		$path      = parse_url( $url, PHP_URL_PATH );
 		$file_name = '';
@@ -1220,7 +1220,7 @@ class WP_Import extends WP_Importer {
 	 * so try again. Similarly for child menu items and menu items which were missing
 	 * the object (e.g. post) they represent in the menu
 	 */
-	function backfill_parents() {
+	public function backfill_parents() {
 		global $wpdb;
 
 		// find parents for post orphans
@@ -1266,7 +1266,7 @@ class WP_Import extends WP_Importer {
 	/**
 	 * Use stored mapping information to update old attachment URLs
 	 */
-	function backfill_attachment_urls() {
+	public function backfill_attachment_urls() {
 		global $wpdb;
 		// make sure we do the longest urls first, in case one is a substring of another
 		uksort( $this->url_remap, array( &$this, 'cmpr_strlen' ) );
@@ -1282,7 +1282,7 @@ class WP_Import extends WP_Importer {
 	/**
 	 * Update _thumbnail_id meta to new, imported attachment IDs
 	 */
-	function remap_featured_images() {
+	public function remap_featured_images() {
 		// cycle through posts that have a featured image
 		foreach ( $this->featured_images as $post_id => $value ) {
 			if ( isset( $this->processed_posts[ $value ] ) ) {
@@ -1301,13 +1301,13 @@ class WP_Import extends WP_Importer {
 	 * @param string $file Path to WXR file for parsing
 	 * @return array Information gathered from the WXR file
 	 */
-	function parse( $file ) {
+	public function parse( $file ) {
 		$parser = new WXR_Parser();
 		return $parser->parse( $file );
 	}
 
 	// Display import page title
-	function header() {
+	public function header() {
 		echo '<div class="wrap">';
 		echo '<h2>' . __( 'Import WordPress', 'wordpress-importer' ) . '</h2>';
 
@@ -1322,14 +1322,14 @@ class WP_Import extends WP_Importer {
 	}
 
 	// Close div.wrap
-	function footer() {
+	public function footer() {
 		echo '</div>';
 	}
 
 	/**
 	 * Display introductory text and file upload form
 	 */
-	function greet() {
+	public function greet() {
 		echo '<div class="narrow">';
 		echo '<p>' . __( 'Howdy! Upload your WordPress eXtended RSS (WXR) file and we&#8217;ll import the posts, pages, comments, custom fields, categories, and tags into this site.', 'wordpress-importer' ) . '</p>';
 		echo '<p>' . __( 'Choose a WXR (.xml) file to upload, then click Upload file and import.', 'wordpress-importer' ) . '</p>';
@@ -1343,7 +1343,7 @@ class WP_Import extends WP_Importer {
 	 * @param string $key The meta key to check
 	 * @return string|bool The key if we do want to import, false if not
 	 */
-	function is_valid_meta_key( $key ) {
+	public function is_valid_meta_key( $key ) {
 		// skip attachment metadata since we'll regenerate it from scratch
 		// skip _edit_lock as not relevant for import
 		if ( in_array( $key, array( '_wp_attached_file', '_wp_attachment_metadata', '_edit_lock' ), true ) ) {
@@ -1358,7 +1358,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @return bool True if creating users is allowed
 	 */
-	function allow_create_users() {
+	public function allow_create_users() {
 		return apply_filters( 'import_allow_create_users', true );
 	}
 
@@ -1369,7 +1369,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @return bool True if downloading attachments is allowed
 	 */
-	function allow_fetch_attachments() {
+	public function allow_fetch_attachments() {
 		return apply_filters( 'import_allow_fetch_attachments', true );
 	}
 
@@ -1379,7 +1379,7 @@ class WP_Import extends WP_Importer {
 	 *
 	 * @return int Maximum attachment file size to import
 	 */
-	function max_attachment_size() {
+	public function max_attachment_size() {
 		return apply_filters( 'import_attachment_size_limit', 0 );
 	}
 
@@ -1387,12 +1387,12 @@ class WP_Import extends WP_Importer {
 	 * Added to http_request_timeout filter to force timeout at 60 seconds during import
 	 * @return int 60
 	 */
-	function bump_request_timeout( $val ) {
+	public function bump_request_timeout( $val ) {
 		return 60;
 	}
 
 	// return the difference in length between two strings
-	function cmpr_strlen( $a, $b ) {
+	public function cmpr_strlen( $a, $b ) {
 		return strlen( $b ) - strlen( $a );
 	}
 

--- a/src/parsers.php
+++ b/src/parsers.php
@@ -9,13 +9,13 @@
 _deprecated_file( basename( __FILE__ ), '0.7.0' );
 
 /** WXR_Parser class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser.php';
+require_once __DIR__ . '/parsers/class-wxr-parser.php';
 
 /** WXR_Parser_SimpleXML class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser-simplexml.php';
+require_once __DIR__ . '/parsers/class-wxr-parser-simplexml.php';
 
 /** WXR_Parser_XML class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser-xml.php';
+require_once __DIR__ . '/parsers/class-wxr-parser-xml.php';
 
 /** WXR_Parser_Regex class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser-regex.php';
+require_once __DIR__ . '/parsers/class-wxr-parser-regex.php';

--- a/src/parsers/class-wxr-parser-regex.php
+++ b/src/parsers/class-wxr-parser-regex.php
@@ -19,11 +19,11 @@ class WXR_Parser_Regex {
 	public $base_blog_url = '';
 	public $has_gzip;
 
-	function __construct() {
+	public function __construct() {
 		$this->has_gzip = is_callable( 'gzopen' );
 	}
 
-	function parse( $file ) {
+	public function parse( $file ) {
 		$wxr_version  = false;
 		$in_multiline = false;
 
@@ -114,7 +114,7 @@ class WXR_Parser_Regex {
 		);
 	}
 
-	function get_tag( $string, $tag ) {
+	public function get_tag( $string, $tag ) {
 		preg_match( "|<$tag.*?>(.*?)</$tag>|is", $string, $return );
 		if ( isset( $return[1] ) ) {
 			if ( substr( $return[1], 0, 9 ) == '<![CDATA[' ) {
@@ -136,7 +136,7 @@ class WXR_Parser_Regex {
 		return $return;
 	}
 
-	function process_category( $c ) {
+	public function process_category( $c ) {
 		$term = array(
 			'term_id'              => $this->get_tag( $c, 'wp:term_id' ),
 			'cat_name'             => $this->get_tag( $c, 'wp:cat_name' ),
@@ -153,7 +153,7 @@ class WXR_Parser_Regex {
 		return $term;
 	}
 
-	function process_tag( $t ) {
+	public function process_tag( $t ) {
 		$term = array(
 			'term_id'         => $this->get_tag( $t, 'wp:term_id' ),
 			'tag_name'        => $this->get_tag( $t, 'wp:tag_name' ),
@@ -169,7 +169,7 @@ class WXR_Parser_Regex {
 		return $term;
 	}
 
-	function process_term( $t ) {
+	public function process_term( $t ) {
 		$term = array(
 			'term_id'          => $this->get_tag( $t, 'wp:term_id' ),
 			'term_taxonomy'    => $this->get_tag( $t, 'wp:term_taxonomy' ),
@@ -187,7 +187,7 @@ class WXR_Parser_Regex {
 		return $term;
 	}
 
-	function process_meta( $string, $tag ) {
+	public function process_meta( $string, $tag ) {
 		$parsed_meta = array();
 
 		preg_match_all( "|<$tag>(.+?)</$tag>|is", $string, $meta );
@@ -206,7 +206,7 @@ class WXR_Parser_Regex {
 		return $parsed_meta;
 	}
 
-	function process_author( $a ) {
+	public function process_author( $a ) {
 		return array(
 			'author_id'           => $this->get_tag( $a, 'wp:author_id' ),
 			'author_login'        => $this->get_tag( $a, 'wp:author_login' ),
@@ -217,7 +217,7 @@ class WXR_Parser_Regex {
 		);
 	}
 
-	function process_post( $post ) {
+	public function process_post( $post ) {
 		$post_id        = $this->get_tag( $post, 'wp:post_id' );
 		$post_title     = $this->get_tag( $post, 'title' );
 		$post_date      = $this->get_tag( $post, 'wp:post_date' );
@@ -314,32 +314,32 @@ class WXR_Parser_Regex {
 		return $postdata;
 	}
 
-	function _normalize_tag( $matches ) {
+	public function _normalize_tag( $matches ) {
 		return '<' . strtolower( $matches[1] );
 	}
 
-	function fopen( $filename, $mode = 'r' ) {
+	public function fopen( $filename, $mode = 'r' ) {
 		if ( $this->has_gzip ) {
 			return gzopen( $filename, $mode );
 		}
 		return fopen( $filename, $mode );
 	}
 
-	function feof( $fp ) {
+	public function feof( $fp ) {
 		if ( $this->has_gzip ) {
 			return gzeof( $fp );
 		}
 		return feof( $fp );
 	}
 
-	function fgets( $fp, $len = 8192 ) {
+	public function fgets( $fp, $len = 8192 ) {
 		if ( $this->has_gzip ) {
 			return gzgets( $fp, $len );
 		}
 		return fgets( $fp, $len );
 	}
 
-	function fclose( $fp ) {
+	public function fclose( $fp ) {
 		if ( $this->has_gzip ) {
 			return gzclose( $fp );
 		}

--- a/src/parsers/class-wxr-parser-regex.php
+++ b/src/parsers/class-wxr-parser-regex.php
@@ -114,8 +114,8 @@ class WXR_Parser_Regex {
 		);
 	}
 
-	public function get_tag( $string, $tag ) {
-		preg_match( "|<$tag.*?>(.*?)</$tag>|is", $string, $return );
+	public function get_tag( $text, $tag ) {
+		preg_match( "|<$tag.*?>(.*?)</$tag>|is", $text, $return );
 		if ( isset( $return[1] ) ) {
 			if ( substr( $return[1], 0, 9 ) == '<![CDATA[' ) {
 				if ( strpos( $return[1], ']]]]><![CDATA[>' ) !== false ) {
@@ -187,10 +187,10 @@ class WXR_Parser_Regex {
 		return $term;
 	}
 
-	public function process_meta( $string, $tag ) {
+	public function process_meta( $text, $tag ) {
 		$parsed_meta = array();
 
-		preg_match_all( "|<$tag>(.+?)</$tag>|is", $string, $meta );
+		preg_match_all( "|<$tag>(.+?)</$tag>|is", $text, $meta );
 
 		if ( ! isset( $meta[1] ) ) {
 			return $parsed_meta;

--- a/src/parsers/class-wxr-parser-simplexml.php
+++ b/src/parsers/class-wxr-parser-simplexml.php
@@ -10,7 +10,7 @@
  * WXR Parser that makes use of the SimpleXML PHP extension.
  */
 class WXR_Parser_SimpleXML {
-	function parse( $file ) {
+	public function parse( $file ) {
 		$authors    = array();
 		$posts      = array();
 		$categories = array();

--- a/src/parsers/class-wxr-parser-simplexml.php
+++ b/src/parsers/class-wxr-parser-simplexml.php
@@ -19,7 +19,7 @@ class WXR_Parser_SimpleXML {
 
 		$internal_errors = libxml_use_internal_errors( true );
 
-		$dom       = new DOMDocument;
+		$dom       = new DOMDocument();
 		$old_value = null;
 		if ( function_exists( 'libxml_disable_entity_loader' ) && PHP_VERSION_ID < 80000 ) {
 			$old_value = libxml_disable_entity_loader( true );

--- a/src/parsers/class-wxr-parser-xml.php
+++ b/src/parsers/class-wxr-parser-xml.php
@@ -73,7 +73,7 @@ class WXR_Parser_XML {
 	public $base_url;
 	public $base_blog_url;
 
-	function parse( $file ) {
+	public function parse( $file ) {
 		$this->wxr_version = false;
 		$this->in_post     = false;
 		$this->cdata       = false;
@@ -119,7 +119,7 @@ class WXR_Parser_XML {
 		);
 	}
 
-	function tag_open( $parse, $tag, $attr ) {
+	public function tag_open( $parse, $tag, $attr ) {
 		if ( in_array( $tag, $this->wp_tags, true ) ) {
 			$this->in_tag = substr( $tag, 3 );
 			return;
@@ -174,7 +174,7 @@ class WXR_Parser_XML {
 		}
 	}
 
-	function cdata( $parser, $cdata ) {
+	public function cdata( $parser, $cdata ) {
 		if ( ! trim( $cdata ) ) {
 			return;
 		}
@@ -186,7 +186,7 @@ class WXR_Parser_XML {
 		}
 	}
 
-	function tag_close( $parser, $tag ) {
+	public function tag_close( $parser, $tag ) {
 		switch ( $tag ) {
 			case 'wp:comment':
 				unset( $this->sub_data['key'], $this->sub_data['value'] ); // remove meta sub_data

--- a/src/parsers/class-wxr-parser.php
+++ b/src/parsers/class-wxr-parser.php
@@ -13,7 +13,7 @@ class WXR_Parser {
 	public function parse( $file ) {
 		// Attempt to use proper XML parsers first
 		if ( extension_loaded( 'simplexml' ) ) {
-			$parser = new WXR_Parser_SimpleXML;
+			$parser = new WXR_Parser_SimpleXML();
 			$result = $parser->parse( $file );
 
 			// If SimpleXML succeeds or this is an invalid WXR file then return the results
@@ -21,7 +21,7 @@ class WXR_Parser {
 				return $result;
 			}
 		} elseif ( extension_loaded( 'xml' ) ) {
-			$parser = new WXR_Parser_XML;
+			$parser = new WXR_Parser_XML();
 			$result = $parser->parse( $file );
 
 			// If XMLParser succeeds or this is an invalid WXR file then return the results
@@ -47,7 +47,7 @@ class WXR_Parser {
 		}
 
 		// use regular expressions if nothing else available or this is bad XML
-		$parser = new WXR_Parser_Regex;
+		$parser = new WXR_Parser_Regex();
 		return $parser->parse( $file );
 	}
 }

--- a/src/parsers/class-wxr-parser.php
+++ b/src/parsers/class-wxr-parser.php
@@ -10,7 +10,7 @@
  * WordPress Importer class for managing parsing of WXR files.
  */
 class WXR_Parser {
-	function parse( $file ) {
+	public function parse( $file ) {
 		// Attempt to use proper XML parsers first
 		if ( extension_loaded( 'simplexml' ) ) {
 			$parser = new WXR_Parser_SimpleXML;

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -34,22 +34,22 @@ if ( ! class_exists( 'WP_Importer' ) ) {
 }
 
 /** Functions missing in older WordPress versions. */
-require_once dirname( __FILE__ ) . '/compat.php';
+require_once __DIR__ . '/compat.php';
 
 /** WXR_Parser class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser.php';
+require_once __DIR__ . '/parsers/class-wxr-parser.php';
 
 /** WXR_Parser_SimpleXML class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser-simplexml.php';
+require_once __DIR__ . '/parsers/class-wxr-parser-simplexml.php';
 
 /** WXR_Parser_XML class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser-xml.php';
+require_once __DIR__ . '/parsers/class-wxr-parser-xml.php';
 
 /** WXR_Parser_Regex class */
-require_once dirname( __FILE__ ) . '/parsers/class-wxr-parser-regex.php';
+require_once __DIR__ . '/parsers/class-wxr-parser-regex.php';
 
 /** WP_Import class */
-require_once dirname( __FILE__ ) . '/class-wp-import.php';
+require_once __DIR__ . '/class-wp-import.php';
 
 function wordpress_importer_init() {
 	load_plugin_textdomain( 'wordpress-importer' );

--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -5,4 +5,4 @@
  */
 
 // This file is included purely for those using Git and checking out directly into wp-content/plugins/wordpress-importer/
-include dirname( __FILE__ ) . '/src/wordpress-importer.php';
+include __DIR__ . '/src/wordpress-importer.php';

--- a/wordpress-importer.php
+++ b/wordpress-importer.php
@@ -5,4 +5,4 @@
  */
 
 // This file is included purely for those using Git and checking out directly into wp-content/plugins/wordpress-importer/
-include __DIR__ . '/src/wordpress-importer.php';
+require_once __DIR__ . '/src/wordpress-importer.php';


### PR DESCRIPTION
### Composer: update to WordPressCS 3.

#### Composer:
* No need for requiring the Composer PHPCS plugin anymore as it now comes automatically with WPCS and removing the requirement allows WPCS to manage the supported versions, preventing conflicts (and will update to the 1.0.0 version).

#### PHPCS ruleset:
* Minor tweak for a replaced sniff as per the changes in WPCS 3.0.0.
* Exclude one error code which would conflict with the minimum PHP requirement of this plugin.

Refs:
* https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0
* https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-ruleset-maintainers

### CS/QA: all methods should have visibility declared

To prevent any BC-breaks, all methods without explicit visibility have now been explicitly declared as `public`.

Mind: the `set_up()` and `tear_down()` methods in the tests _should_ be `protected`, but as WP Core didn't always have this correct and this plugin still supports a large range of WP versions, so needs to take a large range of WP versions into account for the WP Core test framework on which the test suite is build, setting the visibility to `public` is the safer choice for now.

### CS/QA: all properties should have visibility declared

To prevent any BC-breaks, all properties without explicit visibility have now been explicitly declared as `public`.

### CS: always use parentheses for class instantiation

### CS/QA: don't use reserved keywords as parameter names

... to prevent code getting really confusing when people would call it using PHP 8.0+ function calls with named arguments.

### Modernize: use the magic __DIR__ constant

### CS/QA: miscellaneous other fixes

* Use pre-increment instead of post-increment.
* Use `require` for unconditional file includes.
* No blank line at end of function.