### PR TITLE
PHP 8.4 | Remove use of xml_set_object()

### DIFF
--- a/src/parsers/class-wxr-parser-xml.php
+++ b/src/parsers/class-wxr-parser-xml.php
@@ -90,9 +90,8 @@ class WXR_Parser_XML {
 		$xml = xml_parser_create( 'UTF-8' );
 		xml_parser_set_option( $xml, XML_OPTION_SKIP_WHITE, 1 );
 		xml_parser_set_option( $xml, XML_OPTION_CASE_FOLDING, 0 );
-		xml_set_object( $xml, $this );
-		xml_set_character_data_handler( $xml, 'cdata' );
-		xml_set_element_handler( $xml, 'tag_open', 'tag_close' );
+		xml_set_character_data_handler( $xml, array( $this, 'cdata' ) );
+		xml_set_element_handler( $xml, array( $this, 'tag_open' ), array( $this, 'tag_close' ) );
 
 		if ( ! xml_parse( $xml, file_get_contents( $file ), true ) ) {
 			$current_line   = xml_get_current_line_number( $xml );

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -44,6 +44,7 @@ If you would prefer to do things manually then follow these instructions:
 
 * Update compatibility tested-up-to to WordPress 6.7.
 * Update call to `post_exists` to include `post_type` in the query
+* PHP 8.4 compatibility fixes.
 
 = 0.8.2 =
 


### PR DESCRIPTION
The XML Parser extension still supports a quite dated mechanism for method based callbacks, where the object is first set via `xml_set_object()` and the callbacks are then set by passing only the name of the method to the relevant parameters on any of the `xml_set_*_handler()` functions.
```php
xml_set_object( $parser, $my_obj );
xml_set_character_data_handler( $parser, 'method_name_on_my_obj' );
```

Passing proper callables to the `xml_set_*_handler()` functions has been supported for the longest time and is cross-version compatible. So the above code is 100% equivalent to:
```php
xml_set_character_data_handler( $parser, [$my_obj, 'method_name_on_my_obj'] );
```

The mechanism of setting the callbacks with `xml_set_object()` has now been deprecated as of PHP 8.4, in favour of passing proper callables to the `xml_set_*_handler()` functions. This is also means that calling the `xml_set_object()` function is deprecated as well.

This commit fixes these deprecations for this codebase.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
* https://www.php.net/manual/en/function.xml-set-object.php
* https://www.php.net/manual/en/ref.xml.php