### PR TITLE
Test plugin for WordPress 6.6.2 and 6.7-beta2

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 6.4.2
+Tested up to: 6.6.2
 Requires PHP: 5.6
 Stable tag: 0.8.2
 License: GPLv2 or later

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 6.6.2
+Tested up to: 6.7
 Requires PHP: 5.6
 Stable tag: 0.8.2
 License: GPLv2 or later


### PR DESCRIPTION
This PR updates the `Tested up to` label to WordPress 6.7-beta2.

Tested with WordPress 6.6.2 and 6.7-beta2
Tested with PHP `7.0`, `7.4`, `8.0`, `8.2`, `8.3`

How to test:
1. Clone the plugin under your working directory
2. Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
It'll be easier to have a `.wp-env.json` file in the root folder. For example, if your root folder is blogger-importer, you can clone the plugin under this folder. Create a `.wp-env.json` file; you can change the PHP version to the one you want to test with.
```json
{
  "phpVersion": "7.4",
  "plugins": ["./wordpress-importer"]
}
```
Run `wp-env start` to spin up the WordPress.

Navigate to `http://localhost:8888/wp-admin/admin.php?import=wordpress` and upload a file.
Import the content using the download attachment option and without.. it can take a while if you have a lot of content. If the script timeout, you need to `set_time_limit` to a higher value.

Check and see if the import works fine without errors and warnings.