### PR TITLE
GH Actions: run the tests against PHP 8.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,13 @@ jobs:
 
         include:
           # Complement the builds run via the matrix with high/low WP builds for PHP 5.6 and PHP 7.4 up to 8.3.
+          # PHP 8.4 is beta-supported since WP 6.7.
+          - php: '8.4'
+            wp: 'latest'
+            experimental: false
+          - php: '8.4'
+            wp: '6.7'
+            experimental: false
           # PHP 8.3 is beta-supported since WP 6.4.
           - php: '8.3'
             wp: 'latest'


### PR DESCRIPTION
PHP 8.4 has been released and WP 6.7 is beta-compatible.

Ref: https://www.php.net/releases/8.4/en.php