### PR TITLE
wp:author entries can be multiline

### DIFF
--- a/phpunit/data/valid-wxr-1.1.xml
+++ b/phpunit/data/valid-wxr-1.1.xml
@@ -36,6 +36,14 @@
 	<wp:base_blog_url>http://localhost/</wp:base_blog_url>
 
 	<wp:author><wp:author_id>2</wp:author_id><wp:author_login>john</wp:author_login><wp:author_email>johndoe@example.org</wp:author_email><wp:author_display_name><![CDATA[John Doe]]></wp:author_display_name><wp:author_first_name><![CDATA[John]]></wp:author_first_name><wp:author_last_name><![CDATA[Doe]]></wp:author_last_name></wp:author>
+	<wp:author>
+		<wp:author_id>3</wp:author_id>
+		<wp:author_login>jane</wp:author_login>
+		<wp:author_email>janedoe@example.org</wp:author_email>
+		<wp:author_display_name><![CDATA[Jane Doe]]></wp:author_display_name>
+		<wp:author_first_name><![CDATA[Jane]]></wp:author_first_name>
+		<wp:author_last_name><![CDATA[Doe]]></wp:author_last_name>
+	</wp:author>
 
 	<wp:category><wp:term_id>3</wp:term_id><wp:category_nicename>alpha</wp:category_nicename><wp:category_parent></wp:category_parent><wp:cat_name><![CDATA[alpha]]></wp:cat_name><wp:category_description><![CDATA[The alpha category]]></wp:category_description></wp:category>
 	<wp:tag><wp:term_id>22</wp:term_id><wp:tag_slug>clippable</wp:tag_slug><wp:tag_name><![CDATA[Clippable]]></wp:tag_name><wp:tag_description><![CDATA[The Clippable post_tag]]></wp:tag_description></wp:tag>

--- a/phpunit/tests/parser.php
+++ b/phpunit/tests/parser.php
@@ -82,6 +82,18 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 			);
 			$this->assertEqualSetsWithIndex(
 				array(
+					'author_id'           => 3,
+					'author_login'        => 'jane',
+					'author_email'        => 'janedoe@example.org',
+					'author_display_name' => 'Jane Doe',
+					'author_first_name'   => 'Jane',
+					'author_last_name'    => 'Doe',
+				),
+				$result['authors']['jane'],
+				$message
+			);
+			$this->assertEqualSetsWithIndex(
+				array(
 					'term_id'              => 3,
 					'category_nicename'    => 'alpha',
 					'category_parent'      => '',


### PR DESCRIPTION
Wordpress exported WXR files might contain author entries broken in multiple lines. Currently the plugin is not able to handle these cases, causing the import to fail.

By adding the 'wp:author' to $multiline_tags we are able to handle the tags the same way we handle the rest of the multiline tags

Related issues:
https://github.com/WordPress/wordpress-importer/issues/144
https://github.com/WordPress/wordpress-importer/issues/118
https://github.com/WordPress/wordpress-importer/issues/66