### PR TITLE
Bump minimum PHP version to 7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         experimental: [false]
 
         include:
-          # Complement the builds run via the matrix with high/low WP builds for PHP 5.6 and PHP 7.4 up to 8.3.
+          # Complement the builds run via the matrix with high/low WP builds for PHP 7.4 up to 8.3.
           # PHP 8.4 is beta-supported since WP 6.7.
           - php: '8.4'
             wp: 'latest'
@@ -71,27 +71,7 @@ jobs:
           - php: '7.4'
             wp: '5.4'
             experimental: false
-          # PHP 5.6 was supported up to WP 6.2.
-          - php: '5.6'
-            wp: '6.2'
-            experimental: false
-          - php: '5.6'
-            wp: '5.2'
-            experimental: false
-          # PHP 7.0 was supported up to WP 6.5.
-          - php: '7.0'
-            wp: '5.2'
-            experimental: false
-          - php: '7.0'
-            wp: '6.5'
-            experimental: false
-          # PHP 7.1 was supported up to WP 6.5.
-          - php: '7.1'
-            wp: '5.2'
-            experimental: false
-          - php: '7.1'
-            wp: '6.5'
-            experimental: false
+          # Removed PHP 5.6, 7.0 and 7.1 as minimum supported version is 7.2.
 
           # Complement the builds run via the matrix with some additional builds against specific WP versions.
           - php: '7.3'
@@ -99,9 +79,6 @@ jobs:
             experimental: false
           - php: '7.2'
             wp: '5.7'
-            experimental: false
-          - php: '7.0'
-            wp: '5.8'
             experimental: false
           - php: '7.4'
             wp: '6.3'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "source": "https://github.com/WordPress/wordpress-importer"
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.2"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^3.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,7 +45,7 @@
 -->
 
 	<!-- Supported PHP versions -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibilityWP"/>
 
 </ruleset>

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
 Tested up to: 6.7.2
-Requires PHP: 5.6
+Requires PHP: 7.2
 Stable tag: 0.8.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -8,7 +8,7 @@
  * Author URI:        https://wordpress.org/
  * Version:           0.8.4
  * Requires at least: 5.2
- * Requires PHP:      5.6
+ * Requires PHP:      7.2
  * Text Domain:       wordpress-importer
  * License:           GPLv2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress no longer supports PHP 5.6, 7.0, and 7.1 This PR updates the `wordpress-importer` plugin to reflect that state of affairs. To run on older PHP versions, a legacy version of the plugin can still be used.