### PR TITLE
Use WXR_Parser_XML_Processor as the fallback instead of WXR_Parser_Regex

### DIFF
--- a/src/parsers/class-wxr-parser.php
+++ b/src/parsers/class-wxr-parser.php
@@ -47,7 +47,7 @@ class WXR_Parser {
 		}
 
 		// use regular expressions if nothing else available or this is bad XML
-		$parser = new WXR_Parser_Regex();
+		$parser = new WXR_Parser_XML_Processor();
 		return $parser->parse( $file );
 	}
 }

--- a/src/wordpress-importer.php
+++ b/src/wordpress-importer.php
@@ -45,7 +45,13 @@ require_once __DIR__ . '/parsers/class-wxr-parser-simplexml.php';
 /** WXR_Parser_XML class */
 require_once __DIR__ . '/parsers/class-wxr-parser-xml.php';
 
-/** WXR_Parser_Regex class */
+/**
+ * WXR_Parser_Regex class
+ * @deprecated 0.9.0 Use WXR_Parser_XML_Processor instead. The WXR_Parser_Regex class
+ *             is no longer used by the importer or maintained with bug fixes. The only
+ *             reason it is still included in the codebase is for backwards compatibility
+ *             with plugins that directly reference it.
+ */
 require_once __DIR__ . '/parsers/class-wxr-parser-regex.php';
 
 /** WXR_Parser_XML_Processor class */


### PR DESCRIPTION
Makes `WXR_Parser_XML_Processor` the default fallback when libxml is not available and neither `WXR_Parser_XML`, nor `WXR_Parser_Simple_XML` can be used. This, effectively, makes `WXR_Parser_Regex` an unused legacy code.

Context:

`WXR_Parser_XML_Processor` is [a reliable XML parser](https://github.com/WordPress/wordpress-importer/pull/190) with no libxml dependency. The CI test suite, both PHPUnit and [Playwright](https://github.com/WordPress/wordpress-importer/pull/195), demonstrates that `WXR_Parser_XML_Processor` can handle all the special cases where `WXR_Parser_Regex` fails. Let's, therefore, use it by default.

This PR deprecates the `WXR_Parser_Regex` class but does not remove it. This is to avoid breaking any dependent plugin that directly instantiates it. Removing that class entirely would be a nice cleanup item but it's also a low priority one – let's discuss when there's a good reason to.