### PR TITLE
Bump tested-up-to to 6.8

### DIFF
--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link: https://wordpressfoundation.org/donate/
 Tags: importer, wordpress
 Requires at least: 5.2
-Tested up to: 6.7.2
+Tested up to: 6.8
 Requires PHP: 5.6
 Stable tag: 0.9.0
 License: GPLv2 or later


### PR DESCRIPTION
The minor version shouldn't be specified here.