### PR TITLE
Backport PHP 7.2 type annotations from the php-toolkit repo

### DIFF
--- a/src/php-toolkit/ByteStream/class-bytereadstream.php
+++ b/src/php-toolkit/ByteStream/class-bytereadstream.php
@@ -19,24 +19,24 @@ interface ByteReadStream {
 	 *
 	 * @return int|null The length of the data stream, or null if the length is unknown.
 	 */
-	public function length();
+	public function length(): ?int;
 
 	/**
 	 * Get the current position in the data stream.
 	 *
 	 * @return int The current byte offset in the data stream.
 	 */
-	public function tell();
+	public function tell(): int;
 
 	/**
 	 * Seek to a specific position in the data stream.
 	 *
-	 * @param  int  $offset  The byte offset to seek to.
+	 * @param  int $offset  The byte offset to seek to.
 	 *
 	 * @return void
 	 * @throws ByteStreamException If the offset is invalid.
 	 */
-	public function seek( $offset );
+	public function seek( int $offset );
 
 	/**
 	 * Check if the end of the data stream has been reached.
@@ -45,21 +45,21 @@ interface ByteReadStream {
 	 *
 	 * @return bool Whether the end of the data stream has been reached.
 	 */
-	public function reached_end_of_data();
+	public function reached_end_of_data(): bool;
 
 	/**
 	 * Read the next chunk of bytes from the data stream.
 	 *
 	 * @return int how many bytes were pulled
 	 */
-	public function pull( $n, $mode = self::PULL_NO_MORE_THAN );
+	public function pull( $n, $mode = self::PULL_NO_MORE_THAN ): int;
 
 	/**
 	 * Get the next $n bytes without advancing the pointer.
 	 *
 	 * @return string The bytes read.
 	 */
-	public function peek( $n );
+	public function peek( $n ): string;
 
 	/**
 	 * Returns $n bytes and advances the pointer.
@@ -68,19 +68,19 @@ interface ByteReadStream {
 	 *
 	 * @return string
 	 */
-	public function consume( $n );
+	public function consume( $n ): string;
 
 	/**
 	 * Returns all remaining bytes in the stream.
 	 *
 	 * @return string
 	 */
-	public function consume_all();
+	public function consume_all(): string;
 
 	/**
 	 * Close the data stream.
 	 *
 	 * @return void
 	 */
-	public function close_reading();
+	public function close_reading(): void;
 }

--- a/src/php-toolkit/ByteStream/class-filereadstream.php
+++ b/src/php-toolkit/ByteStream/class-filereadstream.php
@@ -10,14 +10,14 @@ class FileReadStream extends BaseByteReadStream {
 
 	public static function from_path( $file_path ) {
 		if ( ! file_exists( $file_path ) ) {
-			throw new ByteStreamException( sprintf( 'File %s does not exist', $file_path ) );
+			throw new ByteStreamException( esc_html( sprintf( 'File %s does not exist', $file_path ) ) );
 		}
 		if ( ! is_file( $file_path ) ) {
-			throw new ByteStreamException( sprintf( '%s is not a file', $file_path ) );
+			throw new ByteStreamException( esc_html( sprintf( '%s is not a file', $file_path ) ) );
 		}
 		$handle = fopen( $file_path, 'r' );
 		if ( ! $handle ) {
-			throw new ByteStreamException( sprintf( 'Failed to open file %s', $file_path ) );
+			throw new ByteStreamException( esc_html( sprintf( 'Failed to open file %s', $file_path ) ) );
 		}
 
 		return self::from_resource( $handle, filesize( $file_path ) );
@@ -36,7 +36,7 @@ class FileReadStream extends BaseByteReadStream {
 		$this->expected_length = $expected_length;
 	}
 
-	protected function internal_pull( $n ) {
+	protected function internal_pull( $n ): string {
 		$bytes = fread( $this->file_pointer, $n );
 		/**
 		 * Workaround for a streaming bug in WordPress Playground.
@@ -55,7 +55,7 @@ class FileReadStream extends BaseByteReadStream {
 		return $bytes;
 	}
 
-	protected function seek_outside_of_buffer( $target_offset ) {
+	protected function seek_outside_of_buffer( int $target_offset ): void {
 		$this->buffer                   = '';
 		$this->offset_in_current_buffer = 0;
 		$this->bytes_already_forgotten  = $target_offset;
@@ -64,7 +64,7 @@ class FileReadStream extends BaseByteReadStream {
 		}
 	}
 
-	public function close_reading() {
+	public function close_reading(): void {
 		if ( $this->is_read_closed ) {
 			return;
 		}
@@ -76,7 +76,7 @@ class FileReadStream extends BaseByteReadStream {
 		$this->file_pointer = null;
 	}
 
-	protected function internal_reached_end_of_data() {
+	protected function internal_reached_end_of_data(): bool {
 		return ! is_resource( $this->file_pointer ) || feof( $this->file_pointer );
 	}
 }

--- a/src/php-toolkit/DataLiberation/EntityReader/class-wxrentityreader.php
+++ b/src/php-toolkit/DataLiberation/EntityReader/class-wxrentityreader.php
@@ -252,7 +252,7 @@ class WXREntityReader implements EntityReader {
 	 */
 	private $known_entities = array();
 
-	public static function create( ByteReadStream $upstream = null, $cursor = null, $options = array() ) {
+	public static function create( ?ByteReadStream $upstream = null, $cursor = null, $options = array() ) {
 		$xml_cursor = null;
 		if ( null !== $cursor ) {
 			$cursor = json_decode( $cursor, true );
@@ -278,7 +278,7 @@ class WXREntityReader implements EntityReader {
 			$reader->connect_upstream( $upstream );
 			if ( null !== $cursor ) {
 				if ( ! isset( $cursor['upstream'] ) ) {
-					// No upstream cursor means we've processed the
+					// No upstream cursor means we've processed the.
 					// entire input stream.
 					$xml->input_finished();
 					$xml->next_token();
@@ -294,10 +294,9 @@ class WXREntityReader implements EntityReader {
 	/**
 	 * Constructor.
 	 *
-	 * @param  WP_XML_Processor  $xml  The XML processor to use.
+	 * @param XMLProcessor $xml  The XML processor to use.
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
 	protected function __construct( XMLProcessor $xml, $options = array() ) {
 		$this->xml = $xml;
@@ -308,15 +307,15 @@ class WXREntityReader implements EntityReader {
 			return;
 		}
 
-		// Every XML element is a combination of a long-form namespace and a
-		// local element name, e.g. a syntax <wp:post_id> could actually refer
+		// Every XML element is a combination of a long-form namespace and a.
+		// local element name, e.g. a syntax <wp:post_id> could actually refer.
 		// to a (https://wordpress.org/export/1.0/, post_id) element.
 		//
-		// Namespaces are paramount for parsing XML and cannot be ignored. Elements
+		// Namespaces are paramount for parsing XML and cannot be ignored. Elements.
 		// element must be matched based on both their namespace and local name.
 		//
 		// Unfortunately, different WXR files defined the `wp` namespace in a different way.
-		// Folks use a mixture of HTTP vs HTTPS protocols and version numbers. We must
+		// Folks use a mixture of HTTP vs HTTPS protocols and version numbers. We must.
 		// account for all possible options to parse these documents correctly.
 		$wxr_namespaces       = array(
 			'http://wordpress.org/export/1.0/',
@@ -458,9 +457,9 @@ class WXREntityReader implements EntityReader {
 		 *        even after evicting the actual bytes where $last_entity is stored.
 		 */
 		$xml_cursor                             = $this->xml->get_reentrancy_cursor();
-		$xml_cursor                             = json_decode( base64_decode( $xml_cursor ), true );
+		$xml_cursor                             = json_decode( base64_decode( $xml_cursor ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$xml_cursor['upstream_bytes_forgotten'] = $this->entity_opener_byte_offset;
-		$xml_cursor                             = base64_encode( json_encode( $xml_cursor ) );
+		$xml_cursor                             = base64_encode( json_encode( $xml_cursor ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 		return json_encode(
 			array(
@@ -494,7 +493,6 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return string|false The entity type, or false if no entity is being processed.
 	 * @since WP_VERSION
-	 *
 	 */
 	private function get_entity_type() {
 		if ( null !== $this->entity_type ) {
@@ -515,7 +513,6 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return int|null The post ID, or null if no posts have been processed.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_last_post_id() {
 		return $this->last_post_id;
@@ -526,7 +523,6 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return int|null The comment ID, or null if no comments have been processed.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_last_comment_id() {
 		return $this->last_comment_id;
@@ -535,12 +531,11 @@ class WXREntityReader implements EntityReader {
 	/**
 	 * Appends bytes to the input stream.
 	 *
-	 * @param  string  $bytes  The bytes to append.
+	 * @param  string $bytes  The bytes to append.
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
-	public function append_bytes( $bytes ) {
+	public function append_bytes( string $bytes ): void {
 		$this->xml->append_bytes( $bytes );
 	}
 
@@ -549,7 +544,7 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @since WP_VERSION
 	 */
-	public function input_finished() {
+	public function input_finished(): void {
 		$this->xml->input_finished();
 	}
 
@@ -558,9 +553,8 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return bool Whether processing is finished.
 	 * @since WP_VERSION
-	 *
 	 */
-	public function is_finished() {
+	public function is_finished(): bool {
 		return $this->is_finished;
 	}
 
@@ -569,9 +563,8 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return bool Whether processing is paused.
 	 * @since WP_VERSION
-	 *
 	 */
-	public function is_paused_at_incomplete_input() {
+	public function is_paused_at_incomplete_input(): bool {
 		return $this->xml->is_paused_at_incomplete_input();
 	}
 
@@ -580,13 +573,12 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return string|null The error message, or null if no error occurred.
 	 * @since WP_VERSION
-	 *
 	 */
-	public function get_last_error() {
+	public function get_last_error(): ?string {
 		return $this->xml->get_last_error();
 	}
 
-	public function get_xml_exception() {
+	public function get_xml_exception(): ?XMLUnsupportedException {
 		return $this->xml->get_exception();
 	}
 
@@ -595,7 +587,6 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return bool Whether another entity was found.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function next_entity() {
 		if ( $this->is_finished ) {
@@ -605,7 +596,7 @@ class WXREntityReader implements EntityReader {
 			if ( $this->read_next_entity() ) {
 				return true;
 			}
-			// If the read failed because of incomplete input data,
+			// If the read failed because of incomplete input data,.
 			// try pulling more bytes from upstream before giving up.
 			if ( $this->is_paused_at_incomplete_input() ) {
 				if ( $this->pull_upstream_bytes() ) {
@@ -626,7 +617,6 @@ class WXREntityReader implements EntityReader {
 	 *
 	 * @return bool Whether another entity was found.
 	 * @since WP_VERSION
-	 *
 	 */
 	private function read_next_entity() {
 		if ( $this->xml->is_finished() ) {
@@ -646,8 +636,8 @@ class WXREntityReader implements EntityReader {
 		 */
 		if ( $this->entity_type && $this->entity_finished ) {
 			$this->after_entity();
-			// If we finished processing the entity on a closing tag, advance the XML processor to
-			// the next token. Otherwise the array_key_exists( $tag, static::known_entities ) branch
+			// If we finished processing the entity on a closing tag, advance the XML processor to.
+			// the next token. Otherwise the array_key_exists( $tag, static::known_entities ) branch.
 			// below will cause an infinite loop.
 			if ( $this->xml->is_tag_closer() ) {
 				if ( false === $this->xml->next_token() ) {
@@ -720,7 +710,7 @@ class WXREntityReader implements EntityReader {
 					return true;
 				}
 				$this->after_entity();
-				// Only tag openers indicate a new entity. Closers just mean
+				// Only tag openers indicate a new entity. Closers just mean.
 				// the previous entity is finished.
 				if ( $this->xml->is_tag_opener() ) {
 					$this->set_entity_tag( $tag_with_namespace );
@@ -796,7 +786,7 @@ class WXREntityReader implements EntityReader {
 
 			if (
 				! $this->entity_finished &&
-				$this->xml->get_breadcrumbs() === array( array( '', 'rss' ), array( '', 'channel' ) )
+				array( array( '', 'rss' ), array( '', 'channel' ) ) === $this->xml->get_breadcrumbs()
 			) {
 				// Look for site options in children of the <channel> tag.
 				if ( $this->parse_site_option() ) {
@@ -903,7 +893,7 @@ class WXREntityReader implements EntityReader {
 	 * Connects a byte stream to automatically pull bytes from once
 	 * the last input chunk have been processed.
 	 *
-	 * @param  WP_Byte_Reader  $stream  The upstream stream.
+	 * @param  ByteReadStream $stream  The upstream stream.
 	 */
 	public function connect_upstream( ByteReadStream $stream ) {
 		$this->upstream = $stream;
@@ -956,12 +946,11 @@ class WXREntityReader implements EntityReader {
 	/**
 	 * Sets the current entity tag and type.
 	 *
-	 * @param  string  $tag  The entity tag name.
+	 * @param  string $tag_with_namespace  The entity tag name.
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
-	private function set_entity_tag( $tag_with_namespace ) {
+	private function set_entity_tag( string $tag_with_namespace ) {
 		$this->entity_tag = $tag_with_namespace;
 		if ( array_key_exists( $tag_with_namespace, $this->known_entities ) ) {
 			$this->entity_type = $this->known_entities[ $tag_with_namespace ]['type'];

--- a/src/php-toolkit/DataLiberation/EntityReader/interface-entity-reader.php
+++ b/src/php-toolkit/DataLiberation/EntityReader/interface-entity-reader.php
@@ -30,7 +30,7 @@ interface EntityReader {
 	 *
 	 * @return bool Whether we've processed everything from the source
 	 */
-	public function is_finished();
+	public function is_finished(): bool;
 
 	/**
 	 * Returns a cursor position that can be used to resume processing later.

--- a/src/php-toolkit/DataLiberation/class-importentity.php
+++ b/src/php-toolkit/DataLiberation/class-importentity.php
@@ -18,6 +18,32 @@ class ImportEntity {
 	const TYPE_USER         = 'user';
 	const TYPE_SITE_OPTION  = 'site_option';
 
+	const POST_FIELDS = array(
+		'post_title',
+		'link',
+		'guid',
+		'post_excerpt',
+		'post_published_at',
+		'post_author',
+		'post_content',
+		'post_excerpt',
+		'post_id',
+		'post_status',
+		'post_date',
+		'post_date_gmt',
+		'post_modified',
+		'post_modified_gmt',
+		'comment_status',
+		'ping_status',
+		'post_name',
+		'post_parent',
+		'menu_order',
+		'post_type',
+		'post_password',
+		'is_sticky',
+		'attachment_url',
+	);
+
 	private $type;
 	private $data;
 

--- a/src/php-toolkit/Encoding/utf8-decoder.php
+++ b/src/php-toolkit/Encoding/utf8-decoder.php
@@ -36,17 +36,16 @@ if ( ! defined( 'UTF8_DECODER_REJECT' ) ) {
  *     false === utf8_is_valid_byte_stream( "Broken stream: \xC2\xC2", 0, $error_at );
  *     15    === $error_at;
  *
- * @param  string  $bytes  Text to validate as UTF-8 bytes.
- * @param  int  $starting_byte  Byte offset in string where decoding should begin.
- * @param  int|null  $first_error_byte_at  Optional. If provided and byte stream fails to validate,
- *                                      will be set to the byte offset where the first invalid
- *                                      byte appeared. Otherwise, will not be set.
+ * @param  string   $bytes  Text to validate as UTF-8 bytes.
+ * @param  int      $starting_byte  Byte offset in string where decoding should begin.
+ * @param  int|null $first_error_byte_at  Optional. If provided and byte stream fails to validate,
+ *                                     will be set to the byte offset where the first invalid
+ *                                     byte appeared. Otherwise, will not be set.
  *
  * @return bool Whether the given byte stream represents valid UTF-8.
  * @since {WP_VERSION}
- *
  */
-function utf8_is_valid_byte_stream( $bytes, $starting_byte = 0, &$first_error_byte_at = null ) {
+function utf8_is_valid_byte_stream( string $bytes, int $starting_byte = 0, ?int &$first_error_byte_at = null ): bool {
 	$state         = UTF8_DECODER_ACCEPT;
 	$last_start_at = $starting_byte;
 
@@ -73,16 +72,15 @@ function utf8_is_valid_byte_stream( $bytes, $starting_byte = 0, &$first_error_by
  * If the byte stream fails to properly decode as UTF-8 this function will set the
  * byte index of the first error byte and report the number of decoded code points.
  *
- * @param  string  $bytes  Text for which to count code points.
- * @param  int|null  $first_error_byte_at  Optional. If provided, will be set upon finding
- *                                      the first invalid byte.
+ * @param  string   $bytes  Text for which to count code points.
+ * @param  int|null $first_error_byte_at  Optional. If provided, will be set upon finding
+ *                                     the first invalid byte.
  *
  * @return int How many code points were decoded in the given byte stream before an error
  *             or before reaching the end of the string.
  * @since {WP_VERSION}
- *
  */
-function utf8_codepoint_count( $bytes, &$first_error_byte_at = null ) {
+function utf8_codepoint_count( string $bytes, ?int &$first_error_byte_at = null ): int {
 	$state         = UTF8_DECODER_ACCEPT;
 	$last_start_at = 0;
 	$count         = 0;
@@ -119,18 +117,18 @@ function utf8_codepoint_count( $bytes, &$first_error_byte_at = null ) {
  *
  * @access private
  *
- * @param  string  $byte  Next byte to be applied in UTF-8 decoding or validation.
- * @param  int  $state  UTF-8 decoding state, one of the following values:<br><ul>
- *                             <li>`UTF8_DECODER_ACCEPT`: Decoder is ready for a new code point.<br>
- *                             <li>`UTF8_DECODER_REJECT`: An error has occurred.<br>
- *                             Any other positive value: Decoder is waiting for additional bytes.
- * @param  int|null  $codepoint  Optional. If provided, will accumulate the decoded code point as
- *                             each byte is processed. If not provided or unable to decode, will
- *                             not be set, or will be set to invalid and unusable data.
+ * @param  string   $byte  Next byte to be applied in UTF-8 decoding or validation.
+ * @param  int      $state  UTF-8 decoding state, one of the following values:<br><ul>
+ *                                 <li>`UTF8_DECODER_ACCEPT`: Decoder is ready for a new code point.<br>
+ *                                 <li>`UTF8_DECODER_REJECT`: An error has occurred.<br>
+ *                                 Any other positive value: Decoder is waiting for additional bytes.
+ * @param  int|null $codepoint  Optional. If provided, will accumulate the decoded code point as
+ *                            each byte is processed. If not provided or unable to decode, will
+ *                            not be set, or will be set to invalid and unusable data.
  *
  * @return int Next decoder state after processing the current byte.
  */
-function utf8_decoder_apply_byte( $byte, $state, &$codepoint = 0 ) {
+function utf8_decoder_apply_byte( string $byte, int $state, int &$codepoint = 0 ): int {
 	/**
 	 * State classification and transition table for UTF-8 validation.
 	 *
@@ -175,13 +173,13 @@ function utf8_decoder_apply_byte( $byte, $state, &$codepoint = 0 ) {
  * This function does not permit passing negative indices and will return
  * the original string if such are provide.
  *
- * @param  string  $text  Input text from which to extract.
- * @param  int  $from  Start extracting after this many code-points.
- * @param  int  $length  Extract this many code points.
+ * @param  string $text  Input text from which to extract.
+ * @param  int    $from  Start extracting after this many code-points.
+ * @param  int    $length  Extract this many code points.
  *
  * @return string Extracted slice of input string.
  */
-function utf8_substr( $text, $from = 0, $length = null ) {
+function utf8_substr( string $text, int $from = 0, ?int $length = null ): string {
 	if ( $from < 0 || ( isset( $length ) && $length < 0 ) ) {
 		return $text;
 	}
@@ -236,13 +234,13 @@ function utf8_substr( $text, $from = 0, $length = null ) {
  * This function does not permit passing negative indices and will return
  * null if such are provided.
  *
- * @param  string  $text  Input text from which to extract.
- * @param  int  $byte_offset  Start at this byte offset in the input text.
- * @param  int  $matched_bytes  How many bytes were matched to produce the codepoint.
+ * @param  string $text  Input text from which to extract.
+ * @param  int    $byte_offset  Start at this byte offset in the input text.
+ * @param  int    $matched_bytes  How many bytes were matched to produce the codepoint.
  *
  * @return int Unicode codepoint.
  */
-function utf8_codepoint_at( $text, $byte_offset = 0, &$matched_bytes = 0 ) {
+function utf8_codepoint_at( string $text, int $byte_offset = 0, &$matched_bytes = 0 ) {
 	if ( $byte_offset < 0 ) {
 		return null;
 	}
@@ -278,86 +276,27 @@ function utf8_codepoint_at( $text, $byte_offset = 0, &$matched_bytes = 0 ) {
 /**
  * Convert a UTF-8 byte sequence to its Unicode codepoint.
  *
- * @param  string  $character  UTF-8 encoded byte sequence representing a single Unicode character.
+ * @param  string $character  UTF-8 encoded byte sequence representing a single Unicode character.
  *
  * @return int Unicode codepoint.
  */
-function utf8_ord( $character ) {
-	// Convert the byte sequence to its binary representation
+function utf8_ord( string $character ): int {
+	// Convert the byte sequence to its binary representation.
 	$bytes = unpack( 'C*', $character );
 
-	// Initialize the codepoint
+	// Initialize the codepoint.
 	$codepoint = 0;
 
-	// Calculate the codepoint based on the number of bytes
-	if ( count( $bytes ) === 1 ) {
+	// Calculate the codepoint based on the number of bytes.
+	if ( 1 === count( $bytes ) ) {
 		$codepoint = $bytes[1];
-	} elseif ( count( $bytes ) === 2 ) {
+	} elseif ( 2 === count( $bytes ) ) {
 		$codepoint = ( ( $bytes[1] & 0x1F ) << 6 ) | ( $bytes[2] & 0x3F );
-	} elseif ( count( $bytes ) === 3 ) {
+	} elseif ( 3 === count( $bytes ) ) {
 		$codepoint = ( ( $bytes[1] & 0x0F ) << 12 ) | ( ( $bytes[2] & 0x3F ) << 6 ) | ( $bytes[3] & 0x3F );
-	} elseif ( count( $bytes ) === 4 ) {
+	} elseif ( 4 === count( $bytes ) ) {
 		$codepoint = ( ( $bytes[1] & 0x07 ) << 18 ) | ( ( $bytes[2] & 0x3F ) << 12 ) | ( ( $bytes[3] & 0x3F ) << 6 ) | ( $bytes[4] & 0x3F );
 	}
 
 	return $codepoint;
-}
-
-/**
- * Encode a code point number into the UTF-8 encoding.
- *
- * This encoder implements the UTF-8 encoding algorithm for converting
- * a code point into a byte sequence. If it receives an invalid code
- * point it will return the Unicode Replacement Character U+FFFD `�`.
- *
- * Example:
- *
- *     '🅰' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0x1f170 );
- *
- *     // Half of a surrogate pair is an invalid code point.
- *     '�' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0xd83c );
- *
- * @since 6.6.0
- *
- * @see https://www.rfc-editor.org/rfc/rfc3629 For the UTF-8 standard.
- *
- * @param int $codepoint Which code point to convert.
- * @return string Converted code point, or `�` if invalid.
- */
-function codepoint_to_utf8_bytes( $codepoint ) {
-	// Pre-check to ensure a valid code point.
-	if (
-		$codepoint <= 0 ||
-		( $codepoint >= 0xD800 && $codepoint <= 0xDFFF ) ||
-		$codepoint > 0x10FFFF
-	) {
-		return '�';
-	}
-
-	if ( $codepoint <= 0x7F ) {
-		return chr( $codepoint );
-	}
-
-	if ( $codepoint <= 0x7FF ) {
-		$byte1 = chr( ( 0xC0 | ( ( $codepoint >> 6 ) & 0x1F ) ) );
-		$byte2 = chr( $codepoint & 0x3F | 0x80 );
-
-		return "{$byte1}{$byte2}";
-	}
-
-	if ( $codepoint <= 0xFFFF ) {
-		$byte1 = chr( ( $codepoint >> 12 ) | 0xE0 );
-		$byte2 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
-		$byte3 = chr( $codepoint & 0x3F | 0x80 );
-
-		return "{$byte1}{$byte2}{$byte3}";
-	}
-
-	// Any values above U+10FFFF are eliminated above in the pre-check.
-	$byte1 = chr( ( $codepoint >> 18 ) | 0xF0 );
-	$byte2 = chr( ( $codepoint >> 12 ) & 0x3F | 0x80 );
-	$byte3 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
-	$byte4 = chr( $codepoint & 0x3F | 0x80 );
-
-	return "{$byte1}{$byte2}{$byte3}{$byte4}";
 }

--- a/src/php-toolkit/Encoding/utf8-encoder.php
+++ b/src/php-toolkit/Encoding/utf8-encoder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WordPress\Encoding;
+
+/**
+ * UTF-8 encoding pipeline by Dennis Snell (@dmsnell).
+ *
+ * It enables parsing XML documents with incomplete UTF-8 byte sequences
+ * without crashing or depending on the mbstring extension.
+ */
+
+/**
+ * Encode a code point number into the UTF-8 encoding.
+ *
+ * This encoder implements the UTF-8 encoding algorithm for converting
+ * a code point into a byte sequence. If it receives an invalid code
+ * point it will return the Unicode Replacement Character U+FFFD `�`.
+ *
+ * Example:
+ *
+ *     '🅰' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0x1f170 );
+ *
+ *     // Half of a surrogate pair is an invalid code point.
+ *     '�' === WP_HTML_Decoder::codepoint_to_utf8_bytes( 0xd83c );
+ *
+ * @since 6.6.0
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc3629 For the UTF-8 standard.
+ *
+ * @param int $codepoint Which code point to convert.
+ * @return string Converted code point, or `�` if invalid.
+ */
+function codepoint_to_utf8_bytes( $codepoint ) {
+	// Pre-check to ensure a valid code point.
+	if (
+		$codepoint <= 0 ||
+		( $codepoint >= 0xD800 && $codepoint <= 0xDFFF ) ||
+		$codepoint > 0x10FFFF
+	) {
+		return '�';
+	}
+
+	if ( $codepoint <= 0x7F ) {
+		return chr( $codepoint );
+	}
+
+	if ( $codepoint <= 0x7FF ) {
+		$byte1 = chr( ( 0xC0 | ( ( $codepoint >> 6 ) & 0x1F ) ) );
+		$byte2 = chr( $codepoint & 0x3F | 0x80 );
+
+		return "{$byte1}{$byte2}";
+	}
+
+	if ( $codepoint <= 0xFFFF ) {
+		$byte1 = chr( ( $codepoint >> 12 ) | 0xE0 );
+		$byte2 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
+		$byte3 = chr( $codepoint & 0x3F | 0x80 );
+
+		return "{$byte1}{$byte2}{$byte3}";
+	}
+
+	// Any values above U+10FFFF are eliminated above in the pre-check.
+	$byte1 = chr( ( $codepoint >> 18 ) | 0xF0 );
+	$byte2 = chr( ( $codepoint >> 12 ) & 0x3F | 0x80 );
+	$byte3 = chr( ( $codepoint >> 6 ) & 0x3F | 0x80 );
+	$byte4 = chr( $codepoint & 0x3F | 0x80 );
+
+	return "{$byte1}{$byte2}{$byte3}{$byte4}";
+}

--- a/src/php-toolkit/XML/class-xmlattributetoken.php
+++ b/src/php-toolkit/XML/class-xmlattributetoken.php
@@ -92,15 +92,13 @@ class XMLAttributeToken {
 	/**
 	 * Constructor.
 	 *
-	 * @param  string  $name  Attribute name.
-	 * @param  int  $value_start  Attribute value.
-	 * @param  int  $value_length  Number of bytes attribute value spans.
-	 * @param  int  $start  The string offset where the attribute name starts.
-	 * @param  int  $length  Byte length of the entire attribute name or name and value pair expression.
-	 * @param  string  $namespace_prefix  Namespace prefix.
-	 * @param  string  $local_name  Local name.
-	 * @param  string  $namespace  Namespace.
-	 *
+	 * @param  int    $value_start  Attribute value.
+	 * @param  int    $value_length  Number of bytes attribute value spans.
+	 * @param  int    $start  The string offset where the attribute name starts.
+	 * @param  int    $length  Byte length of the entire attribute name or name and value pair expression.
+	 * @param  string $namespace_prefix  Namespace prefix.
+	 * @param  string $local_name  Local name.
+	 * @param  string $namespace_name  Namespace.
 	 */
 	public function __construct( $value_start, $value_length, $start, $length, $namespace_prefix = null, $local_name = null, $namespace_name = null ) {
 		$this->value_starts_at  = $value_start;

--- a/src/php-toolkit/XML/class-xmldecoder.php
+++ b/src/php-toolkit/XML/class-xmldecoder.php
@@ -124,12 +124,12 @@ class XMLDecoder {
 				$zeros_at    = $start_of_potential_reference_at + 2;
 				$base        = 16;
 				$digit_chars = '0123456789abcdefABCDEF';
-				$max_digits  = 6; // `&#x10FFFF;`
+				$max_digits  = 6; // `&#x10FFFF;`.
 			} else {
 				$zeros_at    = $start_of_potential_reference_at + 1;
 				$base        = 10;
 				$digit_chars = '0123456789';
-				$max_digits  = 7; // `&#1114111;`
+				$max_digits  = 7; // `&#1114111;`.
 			}
 
 			$zero_count  = strspn( $text, '0', $zeros_at );
@@ -200,7 +200,7 @@ class XMLDecoder {
 	 *
 	 * @return string|null Parsed entity, if parsed, otherwise `null`.
 	 */
-	public static function next_entity( $text, $starting_byte_offset, $ending_byte_offset, &$entity_at = null ) {
+	public static function next_entity( string $text, int $starting_byte_offset, int $ending_byte_offset, ?int &$entity_at = null ): ?string {
 		$at  = $starting_byte_offset;
 		$end = $ending_byte_offset;
 

--- a/src/php-toolkit/XML/class-xmlelement.php
+++ b/src/php-toolkit/XML/class-xmlelement.php
@@ -56,9 +56,9 @@ class XMLElement {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $local_name Local name.
-	 * @param string $xml_namespace_prefix Namespace prefix.
-	 * @param string $xml_namespace Full XML namespace name.
+	 * @param string                $local_name Local name.
+	 * @param string                $xml_namespace_prefix Namespace prefix.
+	 * @param string                $xml_namespace Full XML namespace name.
 	 * @param array<string, string> $namespaces_in_scope Namespaces in current element's scope.
 	 */
 	public function __construct( $local_name, $xml_namespace_prefix, $xml_namespace, $namespaces_in_scope ) {

--- a/src/php-toolkit/XML/class-xmlprocessor.php
+++ b/src/php-toolkit/XML/class-xmlprocessor.php
@@ -41,7 +41,6 @@ use function WordPress\Encoding\utf8_codepoint_at;
  *        * <!NOTATION, see https://www.w3.org/TR/xml/#sec-entity-decl
  *        * Conditional sections, see https://www.w3.org/TR/xml/#sec-condition-sect
  *
- *
  * @TODO: Support XML 1.1.
  *
  * @TODO: Evaluate the performance of utf8_codepoint_at() against using the mbstring
@@ -637,8 +636,10 @@ class XMLProcessor {
 	/**
 	 * The Name from the DOCTYPE declaration.
 	 *
+	 * ```
 	 * doctypedecl ::= '<!DOCTYPE' S Name (S ExternalID)? S? ('[' intSubset ']' S?)? '>'
 	 *                               ^^^^
+	 * ```
 	 *
 	 * @since WP_VERSION
 	 * @var WP_HTML_Span|null
@@ -648,9 +649,11 @@ class XMLProcessor {
 	/**
 	 * The system literal value from the DOCTYPE declaration.
 	 *
+	 * ```
 	 * doctypedecl ::= '<!DOCTYPE' S Name (S ExternalID)? S? ('[' intSubset ']' S?)? '>'
 	 * ExternalID ::= 'SYSTEM' S SystemLiteral | 'PUBLIC' S PubidLiteral
 	 *                           ^^^^^^^^^^^^^
+	 * ```
 	 *
 	 * Example:
 	 *
@@ -667,12 +670,16 @@ class XMLProcessor {
 	/**
 	 * The public identifier value from the DOCTYPE declaration.
 	 *
+	 * ```
 	 * doctypedecl ::= '<!DOCTYPE' S Name (S ExternalID)? S? ('[' intSubset ']' S?)? '>'
 	 * ExternalID ::= 'SYSTEM' S SystemLiteral | 'PUBLIC' S PubidLiteral
+	 * ```
 	 *                                                      ^^^^^^^^^^^^
 	 * Example:
 	 *
-	 *     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+	 * ```
+	 * <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+	 * ```
 	 *
 	 * In this example, the publid_literal would be:
 	 * "-//W3C//DTD XHTML 1.0 Strict//EN"
@@ -685,7 +692,7 @@ class XMLProcessor {
 	/**
 	 * Memory budget for the processed XML.
 	 *
-	 * append_bytes() will flush the processed bytes whenever the XML buffer
+	 * `append_bytes()` will flush the processed bytes whenever the XML buffer
 	 * exceeds this budget. The lexical updates will be applied and the bookmarks
 	 * will be reset.
 	 *
@@ -734,11 +741,15 @@ class XMLProcessor {
 
 	/**
 	 * Top-level namespaces for the currently parsed document.
+	 *
+	 * @var array
 	 */
 	private $document_namespaces;
 
 	/**
 	 * Tracks open elements and their namespaces while scanning XML.
+	 *
+	 * @var array
 	 */
 	private $stack_of_open_elements = array();
 
@@ -784,7 +795,7 @@ class XMLProcessor {
 			$stack_of_open_elements[] = $element->to_array();
 		}
 
-		return base64_encode(
+		return base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			json_encode(
 				array(
 					'is_finished'              => $this->is_finished(),
@@ -819,7 +830,7 @@ class XMLProcessor {
 
 			return false;
 		}
-		$cursor = base64_decode( $cursor );
+		$cursor = base64_decode( $cursor ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		if ( false === $cursor ) {
 			_doing_it_wrong( __METHOD__, 'Invalid cursor provided to initialize_from_cursor().', '1.0.0' );
 
@@ -855,8 +866,9 @@ class XMLProcessor {
 	 *
 	 * @access private
 	 *
-	 * @param  string  $xml  XML to process.
-	 * @param  string|null  $use_the_static_create_methods_instead  This constructor should not be called manually.
+	 * @param  string      $xml  XML to process.
+	 * @param  array       $document_namespaces  Document namespaces.
+	 * @param  string|null $use_the_static_create_methods_instead  This constructor should not be called manually.
 	 *
 	 * @see XMLProcessor::create_stream()
 	 *
@@ -881,9 +893,9 @@ class XMLProcessor {
 			$document_namespaces,
 			// These initial namespaces cannot be overridden.
 			array(
-				'xml'   => 'http://www.w3.org/XML/1998/namespace', // Predefined, cannot be unbound or changed
-				'xmlns' => 'http://www.w3.org/2000/xmlns/',        // Reserved for xmlns attributes, not a real namespace for elements/attributes
-				''      => '', // Default namespace is initially empty (no namespace)
+				'xml'   => 'http://www.w3.org/XML/1998/namespace', // Predefined, cannot be unbound or changed.
+				'xmlns' => 'http://www.w3.org/2000/xmlns/',        // Reserved for xmlns attributes, not a real namespace for elements/attributes.
+				''      => '', // Default namespace is initially empty (no namespace).
 			)
 		);
 	}
@@ -892,7 +904,7 @@ class XMLProcessor {
 	 * Wipes out the processed XML and appends the next chunk of XML to
 	 * any remaining unprocessed XML.
 	 *
-	 * @param  string  $next_chunk  XML to append.
+	 * @param  string $next_chunk  XML to append.
 	 */
 	public function append_bytes( $next_chunk ) {
 		if ( ! $this->expecting_more_input ) {
@@ -927,7 +939,7 @@ class XMLProcessor {
 	 * @return string The flushed bytes.
 	 */
 	private function flush_processed_xml() {
-		// Flush updates
+		// Flush updates.
 		$this->get_updated_xml();
 
 		$unreferenced_bytes = $this->bytes_already_parsed;
@@ -990,7 +1002,6 @@ class XMLProcessor {
 	 * @since 6.5.0
 	 *
 	 * @access private
-	 *
 	 */
 	protected function parse_next_token() {
 		$was_at = $this->bytes_already_parsed;
@@ -1107,8 +1118,8 @@ class XMLProcessor {
 			$namespaces = $this->get_tag_namespaces_in_scope();
 			foreach ( $this->qualified_attributes as $attribute ) {
 				/**
-				 * xmlns attribute is the default namespace
-				 * xmlns:<prefix> declares a namespace prefix scoped to the current element and its descendants
+				 * `xmlns` attribute is the default namespace
+				 * `xmlns:<prefix>` declares a namespace prefix scoped to the current element and its descendants
 				 *
 				 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
 				 */
@@ -1161,6 +1172,7 @@ class XMLProcessor {
 
 			/**
 			 * Confirm the tag name is valid with respect to XML namespaces.
+			 *
 			 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
 			 */
 			$tag_name = $this->get_tag_name_qualified();
@@ -1229,14 +1241,14 @@ class XMLProcessor {
 				$attribute->namespace                          = $namespace_reference;
 			}
 
-			// Store attributes with their namespaces and discard the temporary
+			// Store attributes with their namespaces and discard the temporary.
 			// qualified attributes array.
 			$this->attributes           = $namespaced_attributes;
 			$this->qualified_attributes = array();
 
 			$this->element = new XMLElement( $tag_local_name, $tag_namespace_prefix, $namespaces[ $tag_namespace_prefix ], $namespaces );
 			// Closers assume $this->element is the element created for the opener.
-			// @see step_in_element
+			// @see step_in_element.
 		}
 
 		/*
@@ -1343,9 +1355,8 @@ class XMLProcessor {
 	 *
 	 * @return bool Whether the parse paused at the start of an incomplete token.
 	 * @since WP_VERSION
-	 *
 	 */
-	public function is_paused_at_incomplete_input() {
+	public function is_paused_at_incomplete_input(): bool {
 		return self::STATE_INCOMPLETE_INPUT === $this->parser_state;
 	}
 
@@ -1354,7 +1365,6 @@ class XMLProcessor {
 	 *
 	 * @return bool Whether the processor finished processing.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function is_finished() {
 		return self::STATE_COMPLETE === $this->parser_state;
@@ -1435,11 +1445,10 @@ class XMLProcessor {
 	 * reaching for it, as inappropriate use could lead to broken
 	 * XML structure or unwanted processing overhead.
 	 *
-	 * @param  string  $name  Identifies this particular bookmark.
+	 * @param  string $name  Identifies this particular bookmark.
 	 *
 	 * @return bool Whether the bookmark was successfully created.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function set_bookmark( $name ) {
 		// It only makes sense to set a bookmark if the parser has paused on a concrete token.
@@ -1472,7 +1481,7 @@ class XMLProcessor {
 	 * Releasing a bookmark frees up the small
 	 * performance overhead it requires.
 	 *
-	 * @param  string  $name  Name of the bookmark to remove.
+	 * @param  string $name  Name of the bookmark to remove.
 	 *
 	 * @return bool Whether the bookmark already existed before removal.
 	 */
@@ -1507,9 +1516,8 @@ class XMLProcessor {
 	 * @see self::ERROR_EXCEEDED_MAX_BOOKMARKS
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
-	public function get_last_error() {
+	public function get_last_error(): ?string {
 		return $this->last_error;
 	}
 
@@ -1520,8 +1528,8 @@ class XMLProcessor {
 	 * semantic rules for text nodes. For access to the raw tokens consider using
 	 * XMLProcessor instead.
 	 *
-	 * @param  array|string|null  $query  {
-	 *     Optional. Which tag name to find, having which class, etc. Default is to find any tag.
+	 * @param  array|string|null $query_or_ns  {
+	 *    Optional. Which tag name to find, having which class, etc. Default is to find any tag.
 	 *
 	 * @type string|null $tag_name Which tag to find, or `null` for "any tag."
 	 * @type int|null $match_offset Find the Nth tag matching all search criteria.
@@ -1532,7 +1540,6 @@ class XMLProcessor {
 	 * }
 	 * @return bool Whether a tag was matched.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function next_tag( $query_or_ns = null, $null_or_local_name = null ) {
 		if ( null === $query_or_ns && null === $null_or_local_name ) {
@@ -1569,7 +1576,7 @@ class XMLProcessor {
 			return false;
 		}
 
-		if ( array_keys( $query ) === array( 0, 1 ) && is_string( $query[0] ) && is_string( $query[1] ) ) {
+		if ( array( 0, 1 ) === array_keys( $query ) && is_string( $query[0] ) && is_string( $query[1] ) ) {
 			$query = array( 'breadcrumbs' => array( $query ) );
 		}
 
@@ -1599,7 +1606,7 @@ class XMLProcessor {
 
 		$namespaced_breadcrumbs = array();
 		foreach ( $query['breadcrumbs'] as $breadcrumb ) {
-			if ( is_array( $breadcrumb ) && count( $breadcrumb ) === 2 ) {
+			if ( is_array( $breadcrumb ) && 2 === count( $breadcrumb ) ) {
 				$namespaced_breadcrumbs[] = $breadcrumb;
 			} elseif ( is_string( $breadcrumb ) ) {
 				$namespaced_breadcrumbs[] = array( '', $breadcrumb );
@@ -1637,7 +1644,6 @@ class XMLProcessor {
 	 *
 	 * @return bool Whether a tag was found before the end of the document.
 	 * @since WP_VERSION
-	 *
 	 */
 	private function parse_next_tag() {
 		$this->after_tag();
@@ -1830,7 +1836,7 @@ class XMLProcessor {
 						return false;
 					}
 
-					// @TODO: Expose the "name" value instead of skipping it like that
+					// @TODO: Expose the "name" value instead of skipping it like that.
 					$name_length = $this->parse_name( $at );
 					if ( false === $name_length ) {
 						$this->mark_incomplete_input( 'Unclosed DOCTYPE declaration.' );
@@ -1852,7 +1858,7 @@ class XMLProcessor {
 						return false;
 					}
 
-					// Check for SYSTEM or PUBLIC identifiers
+					// Check for SYSTEM or PUBLIC identifiers.
 					if (
 						$doc_length > $at + 6 &&
 						'S' === $this->xml[ $at ] &&
@@ -1983,7 +1989,7 @@ class XMLProcessor {
 				'm' === $xml[ $at + 3 ] &&
 				'l' === $xml[ $at + 4 ]
 			) {
-				// Setting the parser state early for the get_attribute_by_qualified_name() calls later in this
+				// Setting the parser state early for the get_attribute_by_qualified_name() calls later in this.
 				// branch.
 				$this->parser_state = self::STATE_XML_DECLARATION;
 
@@ -2067,8 +2073,8 @@ class XMLProcessor {
 				$this->bytes_already_parsed = $at + 2;
 				$this->parser_state         = self::STATE_XML_DECLARATION;
 
-				// Processing instructions don't have namespaces. We can just
-				// copy the qualified attributes to the attributes array without
+				// Processing instructions don't have namespaces. We can just.
+				// copy the qualified attributes to the attributes array without.
 				// resolving anything.
 				$this->attributes           = $this->qualified_attributes;
 				$this->qualified_attributes = array();
@@ -2134,7 +2140,7 @@ class XMLProcessor {
 			++$at;
 		}
 
-		// There's no more tag openers and we're not expecting more data –
+		// There's no more tag openers and we're not expecting more data –.
 		// this mist be a trailing text node.
 		if ( ! $this->expecting_more_input ) {
 			$this->parser_state         = self::STATE_TEXT_NODE;
@@ -2165,7 +2171,6 @@ class XMLProcessor {
 	 *
 	 * @return bool Whether an attribute was found before the end of the document.
 	 * @since WP_VERSION
-	 *
 	 */
 	private function parse_next_attribute() {
 		// Skip whitespace and slashes.
@@ -2250,6 +2255,7 @@ class XMLProcessor {
 
 		/**
 		 * Confirm the tag name is valid with respect to XML namespaces.
+		 *
 		 * @see https://www.w3.org/TR/2006/REC-xml-names11-20060816/#Conformance
 		 */
 		if ( false === $this->validate_qualified_name( $attribute_qname ) ) {
@@ -2317,7 +2323,7 @@ class XMLProcessor {
 	 *
 	 * Name ::= NameStartChar (NameChar)*
 	 *
-	 * @param  int  $offset
+	 * @param  int $offset
 	 *
 	 * @return int
 	 */
@@ -2370,41 +2376,41 @@ class XMLProcessor {
 	}
 
 	private function is_valid_name_codepoint( $codepoint, $is_first_character = false ) {
-		// Test against the NameStartChar pattern:
-		// NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-		// See https://www.w3.org/TR/xml/#NT-Name
+		// Test against the NameStartChar pattern:.
+		// NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF].
+		// See `https://www.w3.org/TR/xml/#NT-Name`.
 		if (
-			// :
+			// :.
 			( 0x3A <= $codepoint && $codepoint <= 0x3A ) ||
-			// _
+			// _.
 			( 0x5F <= $codepoint && $codepoint <= 0x5F ) ||
-			// A-Z
+			// A-Z.
 			( 0x41 <= $codepoint && $codepoint <= 0x5A ) ||
-			// a-z
+			// a-z.
 			( 0x61 <= $codepoint && $codepoint <= 0x7A ) ||
-			// [#xC0-#xD6]
+			// [#xC0-#xD6].
 			( 0xC0 <= $codepoint && $codepoint <= 0xD6 ) ||
-			// [#xD8-#xF6]
+			// [#xD8-#xF6].
 			( 0xD8 <= $codepoint && $codepoint <= 0xF6 ) ||
-			// [#xF8-#x2FF]
+			// [#xF8-#x2FF].
 			( 0xF8 <= $codepoint && $codepoint <= 0x2FF ) ||
-			// [#x370-#x37D]
+			// [#x370-#x37D].
 			( 0x370 <= $codepoint && $codepoint <= 0x37D ) ||
-			// [#x37F-#x1FFF]
+			// [#x37F-#x1FFF].
 			( 0x37F <= $codepoint && $codepoint <= 0x1FFF ) ||
-			// [#x200C-#x200D]
+			// [#x200C-#x200D].
 			( 0x200C <= $codepoint && $codepoint <= 0x200D ) ||
-			// [#x2070-#x218F]
+			// [#x2070-#x218F].
 			( 0x2070 <= $codepoint && $codepoint <= 0x218F ) ||
-			// [#x2C00-#x2FEF]
+			// [#x2C00-#x2FEF].
 			( 0x2C00 <= $codepoint && $codepoint <= 0x2FEF ) ||
-			// [#x3001-#xD7FF]
+			// [#x3001-#xD7FF].
 			( 0x3001 <= $codepoint && $codepoint <= 0xD7FF ) ||
-			// [#xF900-#xFDCF]
+			// [#xF900-#xFDCF].
 			( 0xF900 <= $codepoint && $codepoint <= 0xFDCF ) ||
-			// [#xFDF0-#xFFFD]
+			// [#xFDF0-#xFFFD].
 			( 0xFDF0 <= $codepoint && $codepoint <= 0xFFFD ) ||
-			// [#x10000-#xEFFFF]
+			// [#x10000-#xEFFFF].
 			( 0x10000 <= $codepoint && $codepoint <= 0xEFFFF )
 		) {
 			return true;
@@ -2413,21 +2419,21 @@ class XMLProcessor {
 			return false;
 		}
 
-		// Test against the NameChar pattern:
-		// NameChar ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
-		// See https://www.w3.org/TR/xml/#NT-Name
+		// Test against the NameChar pattern:.
+		// NameChar ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040].
+		// See `https://www.w3.org/TR/xml/#NT-Name`.
 		return (
-			// "-"
+			// "-".
 			45 === $codepoint ||
-			// "."
+			// ".".
 			46 === $codepoint ||
-			// [0-9]
+			// [0-9].
 			( 48 <= $codepoint && 57 >= $codepoint ) ||
-			// #xB7
+			// #xB7.
 			183 === $codepoint ||
-			// [#x0300-#x036F]
+			// [#x0300-#x036F].
 			( 0x0300 <= $codepoint && $codepoint <= 0x036F ) ||
-			// [#x203F-#x2040]
+			// [#x203F-#x2040].
 			( 0x203F <= $codepoint && $codepoint <= 0x2040 )
 		);
 	}
@@ -2486,11 +2492,10 @@ class XMLProcessor {
 	/**
 	 * Applies lexical updates to XML document.
 	 *
-	 * @param  int  $shift_this_point  Accumulate and return shift for this position.
+	 * @param  int $shift_this_point  Accumulate and return shift for this position.
 	 *
 	 * @return int How many bytes the given pointer moved in response to the updates.
 	 * @since WP_VERSION
-	 *
 	 */
 	private function apply_lexical_updates( $shift_this_point = 0 ) {
 		if ( ! count( $this->lexical_updates ) ) {
@@ -2584,11 +2589,10 @@ class XMLProcessor {
 	/**
 	 * Checks whether a bookmark with the given name exists.
 	 *
-	 * @param  string  $bookmark_name  Name to identify a bookmark that potentially exists.
+	 * @param  string $bookmark_name  Name to identify a bookmark that potentially exists.
 	 *
 	 * @return bool Whether that bookmark exists.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function has_bookmark( $bookmark_name ) {
 		return array_key_exists( $bookmark_name, $this->bookmarks );
@@ -2604,11 +2608,10 @@ class XMLProcessor {
 	 * In order to prevent accidental infinite loops, there's a
 	 * maximum limit on the number of times seek() can be called.
 	 *
-	 * @param  string  $bookmark_name  Jump to the place in the document identified by this bookmark name.
+	 * @param  string $bookmark_name  Jump to the place in the document identified by this bookmark name.
 	 *
 	 * @return bool Whether the internal cursor was successfully moved to the bookmark's location.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function seek( $bookmark_name ) {
 		if ( ! array_key_exists( $bookmark_name, $this->bookmarks ) ) {
@@ -2644,12 +2647,11 @@ class XMLProcessor {
 	/**
 	 * Compare two WP_HTML_Text_Replacement objects.
 	 *
-	 * @param  WP_HTML_Text_Replacement  $a  First attribute update.
-	 * @param  WP_HTML_Text_Replacement  $b  Second attribute update.
+	 * @param  WP_HTML_Text_Replacement $a  First attribute update.
+	 * @param  WP_HTML_Text_Replacement $b  Second attribute update.
 	 *
 	 * @return int Comparison value for string order.
 	 * @since WP_VERSION
-	 *
 	 */
 	private static function sort_start_ascending( $a, $b ) {
 		$by_start = $a->start - $b->start;
@@ -2679,11 +2681,10 @@ class XMLProcessor {
 	 *  - If an attribute is enqueued to be removed, the return will be `null` to indicate that.
 	 *  - If no updates are enqueued, the return will be `false` to differentiate from "removed."
 	 *
-	 * @param  string  $comparable_name  The attribute name in its comparable form.
+	 * @param  string $comparable_name  The attribute name in its comparable form.
 	 *
 	 * @return string|boolean|null Value of enqueued update if present, otherwise false.
 	 * @since WP_VERSION
-	 *
 	 */
 	private function get_enqueued_attribute_value( $comparable_name ) {
 		if ( self::STATE_MATCHED_TAG !== $this->parser_state ) {
@@ -2763,12 +2764,11 @@ class XMLProcessor {
 	 *     $p->get_attribute( 'http://www.w3.org/1999/xhtml', 'enabled' ) === "true";
 	 *     $p->get_attribute( 'aria-label' ) === null;
 	 *
-	 * @param  string  $namespace_reference  Full namespace of the requested attribute, e.g. "http://wordpress.org/export/1.2/"
-	 * @param  string  $local_name           Name of attribute whose value is requested, e.g. data-test-id
+	 * @param  string $namespace_reference  Full namespace of the requested attribute, e.g. "http://wordpress.org/export/1.2/"
+	 * @param  string $local_name           Name of attribute whose value is requested, e.g. data-test-id
 	 *
 	 * @return string|true|null Value of attribute or `null` if not available. Boolean attributes return `true`.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_attribute( $namespace_reference, $local_name ) {
 		if (
@@ -2892,7 +2892,6 @@ class XMLProcessor {
 	 *
 	 * @return array|null List of [namespace, local_name] pairs, or `null` when no tag opener is matched.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_attribute_names_with_prefix( $full_namespace_prefix, $local_name_prefix ) {
 		if (
@@ -3031,12 +3030,13 @@ class XMLProcessor {
 	/**
 	 * Returns the name from the DOCTYPE declaration.
 	 *
+	 * ```
 	 * doctypedecl ::= '<!DOCTYPE' S Name (S ExternalID)? S? ('[' intSubset ']' S?)? '>'
 	 *                               ^^^^
+	 * ```
 	 *
 	 * @return string|null The name from the DOCTYPE declaration, or null if not available.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_doctype_name() {
 		if ( null === $this->doctype_name ) {
@@ -3059,7 +3059,6 @@ class XMLProcessor {
 	 *
 	 * @return string|null The system literal value, or null if not available.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_system_literal() {
 		if ( null === $this->system_literal ) {
@@ -3081,7 +3080,6 @@ class XMLProcessor {
 	 *
 	 * @return string|null The public identifier value, or null if not available.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_pubid_literal() {
 		if ( null === $this->pubid_literal ) {
@@ -3112,9 +3110,9 @@ class XMLProcessor {
 	 *
 	 * XML tags ending with a solidus ("/") are parsed as empty elements. They have no
 	 * content and no matching closer is expected.
+	 *
 	 * @return bool Whether the currently matched tag is an empty element tag.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function is_empty_element() {
 		if ( self::STATE_MATCHED_TAG !== $this->parser_state ) {
@@ -3147,7 +3145,6 @@ class XMLProcessor {
 	 *
 	 * @return bool Whether the current tag is a tag closer.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function is_tag_closer() {
 		return (
@@ -3170,7 +3167,6 @@ class XMLProcessor {
 	 *
 	 * @return bool Whether the current tag is a tag closer.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function is_tag_opener() {
 		return (
@@ -3198,7 +3194,6 @@ class XMLProcessor {
 	 *
 	 * @return string|null What kind of token is matched, or null.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_token_type() {
 		switch ( $this->parser_state ) {
@@ -3227,7 +3222,6 @@ class XMLProcessor {
 	 *
 	 * @return string|null Name of the matched token.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_token_name() {
 		switch ( $this->parser_state ) {
@@ -3278,7 +3272,6 @@ class XMLProcessor {
 	 *
 	 * @return string
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_modifiable_text() {
 		if ( null === $this->text_starts_at ) {
@@ -3383,12 +3376,12 @@ class XMLProcessor {
 	 *
 	 * For string attributes, the value is escaped using the `esc_attr` function.
 	 *
-	 * @param  string  $name  The attribute name to target.
-	 * @param  string|bool  $value  The new attribute value.
+	 * @param  string      $xml_namespace  The attribute's namespace.
+	 * @param  string      $local_name  The attribute name to target.
+	 * @param  string|bool $value  The new attribute value.
 	 *
 	 * @return bool Whether an attribute value was set.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function set_attribute( $xml_namespace, $local_name, $value ) {
 		if ( ! is_string( $value ) ) {
@@ -3420,6 +3413,7 @@ class XMLProcessor {
 			$prefix = $this->get_tag_namespace_prefix( $xml_namespace );
 			if ( false === $prefix ) {
 				$this->bail(
+					// Translators: 1: The XML namespace.
 					__( 'The namespace "%1$s" is not in the current element\'s scope.' ),
 					$xml_namespace
 				);
@@ -3483,12 +3477,11 @@ class XMLProcessor {
 	/**
 	 * Remove an attribute from the currently-matched tag.
 	 *
-	 * @param  string  $namespace  The attribute's namespace.
-	 * @param  string  $name       The attribute name to remove.
+	 * @param  string $xml_namespace  The attribute's namespace.
+	 * @param  string $local_name     The attribute name to remove.
 	 *
 	 * @return bool Whether an attribute was removed.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function remove_attribute( $xml_namespace, $local_name ) {
 		if (
@@ -3543,7 +3536,6 @@ class XMLProcessor {
 	 * @see XMLProcessor::get_updated_xml()
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
 	public function __toString() {
 		return $this->get_updated_xml();
@@ -3554,7 +3546,6 @@ class XMLProcessor {
 	 *
 	 * @return string The processed XML.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_updated_xml() {
 		$requires_no_updating = 0 === count( $this->lexical_updates );
@@ -3639,14 +3630,13 @@ class XMLProcessor {
 	 * It considers the current XML context (prolog, element, or misc)
 	 * and only expects the nodes that are allowed in that context.
 	 *
-	 * @param  int  $node_to_process  Whether to process the next node or
-	 *            reprocess the current node, e.g. using another parser context.
+	 * @param  int $node_to_process  Whether to process the next node or
+	 *           reprocess the current node, e.g. using another parser context.
 	 *
 	 * @return bool Whether a token was parsed.
 	 * @since WP_VERSION
 	 *
 	 * @access private
-	 *
 	 */
 	private function step( $node_to_process = self::PROCESS_NEXT_NODE ) {
 		// Refuse to proceed if there was a previous error.
@@ -3698,7 +3688,6 @@ class XMLProcessor {
 	 * @see XMLProcessor::step
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
 	private function step_in_prolog( $node_to_process = self::PROCESS_NEXT_NODE ) {
 		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
@@ -3711,7 +3700,7 @@ class XMLProcessor {
 			}
 		}
 
-		// XML requires a root element. If we've reached the end of data in the prolog stage,
+		// XML requires a root element. If we've reached the end of data in the prolog stage,.
 		// before finding a root element, then the document is incomplete.
 		if ( self::STATE_COMPLETE === $this->parser_state ) {
 			$this->mark_incomplete_input();
@@ -3727,8 +3716,8 @@ class XMLProcessor {
 				$text        = $this->get_modifiable_text();
 				$whitespaces = strspn( $text, " \t\n\r" );
 				if ( strlen( $text ) !== $whitespaces ) {
-					// @TODO: Only look for this in the 2 initial bytes of the document:
-					if ( substr( $text, 0, 2 ) == "\xFF\xFE" ) {
+					// @TODO: Only look for this in the 2 initial bytes of the document:.
+					if ( "\xFF\xFE" === substr( $text, 0, 2 ) ) {
 						$this->bail( 'Unexpected UTF-16 BOM byte sequence (0xFFFE) in the document. XMLProcessor only supports UTF-8.', self::ERROR_SYNTAX );
 					}
 					$this->bail( 'Unexpected non-whitespace text token in prolog stage.', self::ERROR_SYNTAX );
@@ -3758,7 +3747,6 @@ class XMLProcessor {
 	 * @see XMLProcessor::step
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
 	private function step_in_element( $node_to_process = self::PROCESS_NEXT_NODE ) {
 		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
@@ -3783,11 +3771,12 @@ class XMLProcessor {
 			case '#processing-instructions':
 				return true;
 			case '#tag':
-				// Update the stack of open elements
+				// Update the stack of open elements.
 				$tag_qname = $this->get_tag_name_qualified();
 				if ( $this->is_tag_closer() ) {
 					if ( ! count( $this->stack_of_open_elements ) ) {
 						$this->bail(
+							// Translators: 1: The closing tag name. 2: The opening tag name.
 							__( 'The closing tag "%1$s" did not match the opening tag "%2$s".' ),
 							$tag_qname,
 							$tag_qname
@@ -3807,7 +3796,7 @@ class XMLProcessor {
 							self::ERROR_SYNTAX
 						);
 					}
-					if ( count( $this->stack_of_open_elements ) === 0 ) {
+					if ( 0 === count( $this->stack_of_open_elements ) ) {
 						$this->parser_context = self::IN_MISC_CONTEXT;
 					}
 				} else {
@@ -3836,7 +3825,6 @@ class XMLProcessor {
 	 * @see XMLProcessor::step
 	 *
 	 * @since WP_VERSION
-	 *
 	 */
 	private function step_in_misc( $node_to_process = self::PROCESS_NEXT_NODE ) {
 		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
@@ -3891,7 +3879,6 @@ class XMLProcessor {
 	 *
 	 * @return string[]|null Array of tag names representing path to matched node, if matched, otherwise NULL.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_breadcrumbs() {
 		return array_map(
@@ -3921,12 +3908,11 @@ class XMLProcessor {
 	 *     false === $processor->matches_breadcrumbs( array( 'post', 'image' ) );
 	 *     true  === $processor->matches_breadcrumbs( array( 'post', '*', 'image' ) );
 	 *
-	 * @param  string[]  $breadcrumbs  DOM sub-path at which element is found, e.g. `array( 'content', 'image' )`.
-	 *                              May also contain the wildcard `*` which matches a single element, e.g. `array( 'post', '*' )`.
+	 * @param  string[] $breadcrumbs  DOM sub-path at which element is found, e.g. `array( 'content', 'image' )`.
+	 *                             May also contain the wildcard `*` which matches a single element, e.g. `array( 'post', '*' )`.
 	 *
 	 * @return bool Whether the currently-matched tag is found at the given nested structure.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function matches_breadcrumbs( $breadcrumbs ) {
 		// Everything matches when there are zero constraints.
@@ -3954,7 +3940,7 @@ class XMLProcessor {
 				return false;
 			}
 
-			// Normalize crumb to [namespace, local_name]
+			// Normalize crumb to [namespace, local_name].
 			if ( ! is_array( $crumb ) ) {
 				if ( '*' === $crumb ) {
 					$crumb = array( '*', '*' );
@@ -3964,12 +3950,12 @@ class XMLProcessor {
 			}
 			list( $namespace, $local_name ) = $crumb;
 
-			// Match local name, respecting wildcard '*'
+			// Match local name, respecting wildcard '*'.
 			if ( '*' !== $local_name && $local_name !== $element->local_name ) {
 				return false;
 			}
 
-			// Match namespace, respecting wildcard '*'
+			// Match namespace, respecting wildcard '*'.
 			if ( '*' !== $namespace && $namespace !== $element->namespace ) {
 				return false;
 			}
@@ -3999,7 +3985,6 @@ class XMLProcessor {
 	 *
 	 * @return int Nesting-depth of current location in the document.
 	 * @since WP_VERSION
-	 *
 	 */
 	public function get_current_depth() {
 		return count( $this->stack_of_open_elements );
@@ -4013,7 +3998,7 @@ class XMLProcessor {
 	 *     $this->parse_qualified_name( 'wp:post' ); // Returns array( 'wp.org', 'post' )
 	 *     $this->parse_qualified_name( 'image' ); // Returns array( '', 'image' )
 	 *
-	 * @param  string  $qualified_name  The qualified name to parse.
+	 * @param  string $qualified_name  The qualified name to parse.
 	 *
 	 * @return array<string, string> The namespace prefix and local name.
 	 */
@@ -4034,7 +4019,7 @@ class XMLProcessor {
 	 * Asserts a qualified tag name is syntactically valid according to the
 	 * XML specification.
 	 *
-	 * @param  string  $qualified_name  The qualified name to validate.
+	 * @param  string $qualified_name  The qualified name to validate.
 	 * @return bool Whether the qualified name is syntactically valid.
 	 */
 	private function validate_qualified_name( $qualified_name ) {
@@ -4091,10 +4076,9 @@ class XMLProcessor {
 	/**
 	 * Stops the parser and terminates its execution when encountering unsupported markup.
 	 *
-	 * @param  string  $message  Explains support is missing in order to parse the current node.
+	 * @param  string $message  Explains support is missing in order to parse the current node.
 	 *
 	 * @throws XMLUnsupportedException Halts execution of the parser.
-	 *
 	 */
 	private function bail( $message, $reason = self::ERROR_UNSUPPORTED ) {
 		$starts_at = isset( $this->token_starts_at ) ? $this->token_starts_at : strlen( $this->xml );

--- a/src/php-toolkit/XML/class-xmlunsupportedexception.php
+++ b/src/php-toolkit/XML/class-xmlunsupportedexception.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * XML API: XMLUnsupportedException class
+ *
+ * @package WordPress\XML
  */
 
 namespace WordPress\XML;
@@ -74,14 +76,13 @@ class XMLUnsupportedException extends Exception {
 	/**
 	 * Constructor function.
 	 *
-	 * @param  string  $message  Brief message explaining what is unsupported, the reason this exception was raised.
-	 * @param  string  $token_name  Normalized name of matched token when this exception was raised.
-	 * @param  int  $token_at  Number of bytes into source XML document where matched token starts.
-	 * @param  string  $token  Full raw text of matched token when this exception was raised.
-	 * @param  string[]  $stack_of_open_elements  Stack of open elements when this exception was raised.
-	 * @param  string[]  $active_formatting_elements  List of active formatting elements when this exception was raised.
+	 * @param  string   $message  Brief message explaining what is unsupported, the reason this exception was raised.
+	 * @param  string   $token_name  Normalized name of matched token when this exception was raised.
+	 * @param  int      $token_at  Number of bytes into source XML document where matched token starts.
+	 * @param  string   $token  Full raw text of matched token when this exception was raised.
+	 * @param  string[] $stack_of_open_elements  Stack of open elements when this exception was raised.
 	 */
-	public function __construct( $message, $token_name, $token_at, $token, $stack_of_open_elements ) {
+	public function __construct( string $message, string $token_name, int $token_at, string $token, array $stack_of_open_elements ) {
 		parent::__construct( $message );
 
 		$this->token_name = $token_name;

--- a/src/php-toolkit/load.php
+++ b/src/php-toolkit/load.php
@@ -14,8 +14,9 @@ if ( ! class_exists( 'WordPress\XML\XMLProcessor' ) ) {
 	require_once __DIR__ . '/XML/class-xmlelement.php';
 	require_once __DIR__ . '/XML/class-xmlunsupportedexception.php';
 	require_once __DIR__ . '/XML/class-xmlprocessor.php';
-	require_once __DIR__ . '/DataLiberation/EntityReader/entity-reader.php';
+	require_once __DIR__ . '/DataLiberation/EntityReader/interface-entity-reader.php';
 	require_once __DIR__ . '/DataLiberation/EntityReader/class-wxrentityreader.php';
-	require_once __DIR__ . '/Encoding/utf8.php';
+	require_once __DIR__ . '/Encoding/utf8-decoder.php';
+	require_once __DIR__ . '/Encoding/utf8-encoder.php';
 	require_once __DIR__ . '/DataLiberation/class-importentity.php';
 }


### PR DESCRIPTION
https://github.com/WordPress/wordpress-importer/pull/190 added a few libraries from the [wordpress/php-toolkit](https://github.com/wordpress/php-toolkit) repo to this repository. They had to be downgraded to PHP 5.6 since that's what the importer plugin required at the time. The minimum PHP version was since [bumped to PHP 7.2](https://github.com/WordPress/wordpress-importer/pull/196) and this PR restores the PHP 7.2 syntax to those classes. In addition, it contains a few PHPCS-related formatting tweaks.

cc @zaerl 
