### PR TITLE
Remove the /* no condition */ comments from Punycode.php

### DIFF
--- a/src/php-toolkit/DataLiberation/vendor-patched/rowbot/punycode/src/Punycode.php
+++ b/src/php-toolkit/DataLiberation/vendor-patched/rowbot/punycode/src/Punycode.php
@@ -374,7 +374,7 @@ final class Punycode {
 			$oldi = $i;
 			$w    = 1;
 
-			for ( $k = self::BASE; /* no condition */; $k += self::BASE ) {
+			for ( $k = self::BASE; ; $k += self::BASE ) {
 				if ( $in >= $inputLength ) {
 					throw new InvalidInputException();
 				}
@@ -496,7 +496,7 @@ final class Punycode {
 				} elseif ( $codePoint === $n ) {
 					$q = $delta;
 
-					for ( $k = self::BASE; /* no condition */; $k += self::BASE ) {
+					for ( $k = self::BASE; ; $k += self::BASE ) {
 						if ( $out >= $maxOut ) {
 							throw new OutputSizeExceededException();
 						}


### PR DESCRIPTION
Paul reported this issue on the WordPress support forums: [[WordPress Importer] Version 0.9.1 trips anti-malware](ttps://wordpress.org/support/topic/version-0-9-1-trips-anti-malware/#post-18646943)

> Version 0.9.1 is tripping up our anti-malware scanner because the following file…
> 
> php-toolkit/DataLiberation/vendor-patched/rowbot/punycode/src/Punycode.php
> …uses a code obfuscation technique. It’s putting comments inside a for statement, like this:
> 
> for ( $k = self::BASE; /* no condition */; $k += self::BASE )
> Putting a comment in there is a technique used by malware to hide nasties.
> 
> Request: Can you please remove these comments from your patched Punycode.php file?

This PR does just that and removes those comments. Thank you for the ping @dd32 

As a follow-up item, let's remove them in the [php-toolkit](https://github.com/wordpress/php-toolkit) repo as well.