### PR TITLE
Rewrite attachment URLs to the new URL structure

### DIFF
--- a/phpunit/data/wxr-flat-attachment-different-site.xml
+++ b/phpunit/data/wxr-flat-attachment-different-site.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+     xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:wp="http://wordpress.org/export/1.2/">
+
+    <channel>
+        <title>Media Export</title>
+        <link>https://wp.org</link>
+        <description></description>
+        <pubDate>Mon, 10 Jan 2011 13:17:54 +0000</pubDate>
+        <language>en-US</language>
+        <wp:wxr_version>1.2</wp:wxr_version>
+        <wp:base_site_url>https://wp.org</wp:base_site_url>
+        <wp:base_blog_url>https://wp.org</wp:base_blog_url>
+
+        <wp:author>
+            <wp:author_id>1</wp:author_id>
+            <wp:author_login><![CDATA[a11yteam]]></wp:author_login>
+            <wp:author_email><![CDATA[a11yteam@example.com]]></wp:author_email>
+            <wp:author_display_name><![CDATA[a11y Team]]></wp:author_display_name>
+            <wp:author_first_name><![CDATA[]]></wp:author_first_name>
+            <wp:author_last_name><![CDATA[]]></wp:author_last_name>
+        </wp:author>
+
+        <generator>https://wordpress.org/?v=6.5.4</generator>
+
+        <item>
+            <title>canola2</title>
+            <link>https://wpthemetestdata.wordpress.com/2010/09/10/canola2/</link>
+            <pubDate>Mon, 10 Jan 2011 13:17:54 +0000</pubDate>
+            <dc:creator><![CDATA[a11yteam]]></dc:creator>
+            <guid isPermaLink="false">https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg</guid>
+            <description/>
+            <content:encoded><![CDATA[]]></content:encoded>
+            <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+            <wp:post_id>611</wp:post_id>
+            <wp:post_date>2011-01-10 06:17:54</wp:post_date>
+            <wp:post_date_gmt>2011-01-10 13:17:54</wp:post_date_gmt>
+            <wp:comment_status>open</wp:comment_status>
+            <wp:ping_status>closed</wp:ping_status>
+            <wp:post_name>canola2</wp:post_name>
+            <wp:status>inherit</wp:status>
+            <wp:post_parent>555</wp:post_parent>
+            <wp:menu_order>0</wp:menu_order>
+            <wp:post_type>attachment</wp:post_type>
+            <wp:post_password/>
+            <wp:is_sticky>0</wp:is_sticky>
+            <wp:attachment_url>https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg</wp:attachment_url>
+            <wp:postmeta>
+                <wp:meta_key>_wp_attachment_image_alt</wp:meta_key>
+                <wp:meta_value><![CDATA[canola]]></wp:meta_value>
+            </wp:postmeta>
+            <wp:postmeta>
+                <wp:meta_key>_wp_attached_file</wp:meta_key>
+                <wp:meta_value><![CDATA[2008/06/canola2.jpg]]></wp:meta_value>
+            </wp:postmeta>
+            <wp:postmeta>
+                <wp:meta_key>_attachment_original_parent_id</wp:meta_key>
+                <wp:meta_value><![CDATA[555]]></wp:meta_value>
+            </wp:postmeta>
+        </item>
+        <item>
+            <title>Post with Attachment</title>
+            <link>https://wp.org/2011/01/10/post-with-attachment/</link>
+            <pubDate>Mon, 10 Jan 2011 13:20:00 +0000</pubDate>
+            <dc:creator><![CDATA[a11yteam]]></dc:creator>
+            <guid isPermaLink="false">https://wp.org/?p=555</guid>
+            <description/>
+            <content:encoded><![CDATA[<p>This post has an attachment.</p>
+
+    <img class="alignnone size-medium wp-image-611" src="https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg" alt="canola" width="100" height="100" />]]></content:encoded>
+            <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+            <wp:post_id>555</wp:post_id>
+            <wp:post_date>2011-01-10 06:20:00</wp:post_date>
+            <wp:post_date_gmt>2011-01-10 13:20:00</wp:post_date_gmt>
+            <wp:comment_status>open</wp:comment_status>
+            <wp:ping_status>open</wp:ping_status>
+            <wp:post_name>post-with-attachment</wp:post_name>
+            <wp:status>publish</wp:status>
+            <wp:post_parent>0</wp:post_parent>
+            <wp:menu_order>0</wp:menu_order>
+            <wp:post_type>post</wp:post_type>
+            <wp:post_password/>
+            <wp:is_sticky>0</wp:is_sticky>
+        </item>
+    </channel>
+</rss>

--- a/phpunit/data/wxr-flat-attachment-same-site.xml
+++ b/phpunit/data/wxr-flat-attachment-same-site.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+     xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:wp="http://wordpress.org/export/1.2/">
+
+    <channel>
+        <title>Media Export</title>
+        <link>https://wpthemetestdata.files.wordpress.com</link>
+        <description></description>
+        <pubDate>Mon, 10 Jan 2011 13:17:54 +0000</pubDate>
+        <language>en-US</language>
+        <wp:wxr_version>1.2</wp:wxr_version>
+        <wp:base_site_url>https://wpthemetestdata.files.wordpress.com</wp:base_site_url>
+        <wp:base_blog_url>https://wpthemetestdata.files.wordpress.com</wp:base_blog_url>
+
+        <wp:author>
+            <wp:author_id>1</wp:author_id>
+            <wp:author_login><![CDATA[a11yteam]]></wp:author_login>
+            <wp:author_email><![CDATA[a11yteam@example.com]]></wp:author_email>
+            <wp:author_display_name><![CDATA[a11y Team]]></wp:author_display_name>
+            <wp:author_first_name><![CDATA[]]></wp:author_first_name>
+            <wp:author_last_name><![CDATA[]]></wp:author_last_name>
+        </wp:author>
+
+        <generator>https://wordpress.org/?v=6.5.4</generator>
+
+        <item>
+            <title>canola2</title>
+            <link>https://wpthemetestdata.wordpress.com/2010/09/10/canola2/</link>
+            <pubDate>Mon, 10 Jan 2011 13:17:54 +0000</pubDate>
+            <dc:creator><![CDATA[a11yteam]]></dc:creator>
+            <guid isPermaLink="false">https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg</guid>
+            <description/>
+            <content:encoded><![CDATA[]]></content:encoded>
+            <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+            <wp:post_id>611</wp:post_id>
+            <wp:post_date>2011-01-10 06:17:54</wp:post_date>
+            <wp:post_date_gmt>2011-01-10 13:17:54</wp:post_date_gmt>
+            <wp:comment_status>open</wp:comment_status>
+            <wp:ping_status>closed</wp:ping_status>
+            <wp:post_name>canola2</wp:post_name>
+            <wp:status>inherit</wp:status>
+            <wp:post_parent>555</wp:post_parent>
+            <wp:menu_order>0</wp:menu_order>
+            <wp:post_type>attachment</wp:post_type>
+            <wp:post_password/>
+            <wp:is_sticky>0</wp:is_sticky>
+            <wp:attachment_url>https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg</wp:attachment_url>
+            <wp:postmeta>
+                <wp:meta_key>_wp_attachment_image_alt</wp:meta_key>
+                <wp:meta_value><![CDATA[canola]]></wp:meta_value>
+            </wp:postmeta>
+            <wp:postmeta>
+                <wp:meta_key>_wp_attached_file</wp:meta_key>
+                <wp:meta_value><![CDATA[2008/06/canola2.jpg]]></wp:meta_value>
+            </wp:postmeta>
+            <wp:postmeta>
+                <wp:meta_key>_attachment_original_parent_id</wp:meta_key>
+                <wp:meta_value><![CDATA[555]]></wp:meta_value>
+            </wp:postmeta>
+        </item>
+        <item>
+            <title>Post with Attachment</title>
+            <link>https://wp.org/2011/01/10/post-with-attachment/</link>
+            <pubDate>Mon, 10 Jan 2011 13:20:00 +0000</pubDate>
+            <dc:creator><![CDATA[a11yteam]]></dc:creator>
+            <guid isPermaLink="false">https://wp.org/?p=555</guid>
+            <description/>
+            <content:encoded><![CDATA[<p>This post has an attachment.</p>
+
+    <img class="alignnone size-medium wp-image-611" src="https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg" alt="canola" width="100" height="100" />]]></content:encoded>
+            <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+            <wp:post_id>555</wp:post_id>
+            <wp:post_date>2011-01-10 06:20:00</wp:post_date>
+            <wp:post_date_gmt>2011-01-10 13:20:00</wp:post_date_gmt>
+            <wp:comment_status>open</wp:comment_status>
+            <wp:ping_status>open</wp:ping_status>
+            <wp:post_name>post-with-attachment</wp:post_name>
+            <wp:status>publish</wp:status>
+            <wp:post_parent>0</wp:post_parent>
+            <wp:menu_order>0</wp:menu_order>
+            <wp:post_type>post</wp:post_type>
+            <wp:post_password/>
+            <wp:is_sticky>0</wp:is_sticky>
+        </item>
+    </channel>
+</rss>

--- a/phpunit/tests/base.php
+++ b/phpunit/tests/base.php
@@ -20,7 +20,7 @@ abstract class WP_Import_UnitTestCase extends WP_UnitTestCase {
 	 * @param array $users User import settings
 	 * @param bool $fetch_files Whether or not do download remote attachments
 	 */
-	protected function _import_wp( $filename, $users = array(), $fetch_files = true ) {
+	protected function _import_wp( $filename, $users = array(), $fetch_files = true, $rewrite_urls = true ) {
 		$importer = new WP_Import();
 		$file     = realpath( $filename );
 
@@ -53,7 +53,7 @@ abstract class WP_Import_UnitTestCase extends WP_UnitTestCase {
 
 		ob_start();
 		$importer->fetch_attachments = $fetch_files;
-		$importer->import( $file );
+		$importer->import( $file, array( 'rewrite_urls' => $rewrite_urls ) );
 		ob_end_clean();
 
 		$_POST = array();

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -6,27 +6,6 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
-	/**
-	 * Holds the URL currently mocked for HTTP requests when downloading attachments.
-	 *
-	 * @var string
-	 */
-	private $mocked_attachment_url = '';
-
-	/**
-	 * Binary contents returned for the mocked attachment download.
-	 *
-	 * @var string
-	 */
-	private $mocked_attachment_body = '';
-
-	/**
-	 * Previous value of the uploads year/month folders option.
-	 *
-	 * @var mixed
-	 */
-	private $previous_uploads_structure = null;
-
 	public function set_up() {
 		parent::set_up();
 
@@ -71,39 +50,39 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		);
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/small-export.xml', $authors );
 
-		// ensure that authors were imported correctly
+		// Ensure that authors were imported correctly.
 		$user_count = count_users();
-		$this->assertEquals( 3, $user_count['total_users'] );
+		$this->assertSame( 3, $user_count['total_users'] );
 		$admin = get_user_by( 'login', 'admin' );
-		$this->assertEquals( 'admin', $admin->user_login );
-		$this->assertEquals( 'local@host.null', $admin->user_email );
+		$this->assertSame( 'admin', $admin->user_login );
+		$this->assertSame( 'local@host.null', $admin->user_email );
 		$editor = get_user_by( 'login', 'editor' );
-		$this->assertEquals( 'editor', $editor->user_login );
-		$this->assertEquals( 'editor@example.org', $editor->user_email );
-		$this->assertEquals( 'FirstName', $editor->user_firstname );
-		$this->assertEquals( 'LastName', $editor->user_lastname );
+		$this->assertSame( 'editor', $editor->user_login );
+		$this->assertSame( 'editor@example.org', $editor->user_email );
+		$this->assertSame( 'FirstName', $editor->user_firstname );
+		$this->assertSame( 'LastName', $editor->user_lastname );
 		$author = get_user_by( 'login', 'author' );
-		$this->assertEquals( 'author', $author->user_login );
-		$this->assertEquals( 'author@example.org', $author->user_email );
+		$this->assertSame( 'author', $author->user_login );
+		$this->assertSame( 'author@example.org', $author->user_email );
 
 		// Check that terms were imported correctly.
 		$this->assertSame( '30', wp_count_terms( array( 'taxonomy' => 'category' ) ) );
 		$this->assertSame( '3', wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
-		$this->assertEquals( 0, $foo->parent );
+		$this->assertSame( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
 		$foo_bar = get_term_by( 'slug', 'foo-bar', 'category' );
-		$this->assertEquals( $bar->term_id, $foo_bar->parent );
+		$this->assertSame( $bar->term_id, $foo_bar->parent );
 
-		// check that posts/pages were imported correctly
+		// Check that posts/pages were imported correctly.
 		$post_count = wp_count_posts( 'post' );
-		$this->assertEquals( 5, $post_count->publish );
-		$this->assertEquals( 1, $post_count->private );
+		$this->assertSame( '5', $post_count->publish );
+		$this->assertSame( '1', $post_count->private );
 		$page_count = wp_count_posts( 'page' );
-		$this->assertEquals( 4, $page_count->publish );
-		$this->assertEquals( 1, $page_count->draft );
+		$this->assertSame( '4', $page_count->publish );
+		$this->assertSame( '1', $page_count->draft );
 		$comment_count = wp_count_comments();
-		$this->assertEquals( 1, $comment_count->total_comments );
+		$this->assertSame( 1, $comment_count->total_comments );
 
 		$posts = get_posts(
 			array(
@@ -113,120 +92,120 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 				'orderby'     => 'ID',
 			)
 		);
-		$this->assertEquals( 11, count( $posts ) );
+		$this->assertCount( 11, $posts );
 
 		$post = $posts[0];
-		$this->assertEquals( 'Many Categories', $post->post_title );
-		$this->assertEquals( 'many-categories', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'post', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
+		$this->assertSame( 'Many Categories', $post->post_title );
+		$this->assertSame( 'many-categories', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertEquals( 27, count( $cats ) );
+		$this->assertCount( 27, $cats );
 
 		$post = $posts[1];
-		$this->assertEquals( 'Non-standard post format', $post->post_title );
-		$this->assertEquals( 'non-standard-post-format', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'post', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
+		$this->assertSame( 'Non-standard post format', $post->post_title );
+		$this->assertSame( 'non-standard-post-format', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertEquals( 1, count( $cats ) );
+		$this->assertCount( 1, $cats );
 		$this->assertTrue( has_post_format( 'aside', $post->ID ) );
 
 		$post = $posts[2];
-		$this->assertEquals( 'Top-level Foo', $post->post_title );
-		$this->assertEquals( 'top-level-foo', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'post', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
+		$this->assertSame( 'Top-level Foo', $post->post_title );
+		$this->assertSame( 'top-level-foo', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID, array( 'fields' => 'all' ) );
-		$this->assertEquals( 1, count( $cats ) );
-		$this->assertEquals( 'foo', $cats[0]->slug );
+		$this->assertCount( 1, $cats );
+		$this->assertSame( 'foo', $cats[0]->slug );
 
 		$post = $posts[3];
-		$this->assertEquals( 'Foo-child', $post->post_title );
-		$this->assertEquals( 'foo-child', $post->post_name );
-		$this->assertEquals( $editor->ID, $post->post_author );
-		$this->assertEquals( 'post', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
+		$this->assertSame( 'Foo-child', $post->post_title );
+		$this->assertSame( 'foo-child', $post->post_name );
+		$this->assertSame( (string) $editor->ID, $post->post_author );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID, array( 'fields' => 'all' ) );
-		$this->assertEquals( 1, count( $cats ) );
-		$this->assertEquals( 'foo-bar', $cats[0]->slug );
+		$this->assertCount( 1, $cats );
+		$this->assertSame( 'foo-bar', $cats[0]->slug );
 
 		$post = $posts[4];
-		$this->assertEquals( 'Private Post', $post->post_title );
-		$this->assertEquals( 'private-post', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'post', $post->post_type );
-		$this->assertEquals( 'private', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
+		$this->assertSame( 'Private Post', $post->post_title );
+		$this->assertSame( 'private-post', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'private', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertEquals( 1, count( $cats ) );
+		$this->assertCount( 1, $cats );
 		$tags = wp_get_post_tags( $post->ID );
-		$this->assertEquals( 3, count( $tags ) );
-		$this->assertEquals( 'tag1', $tags[0]->slug );
-		$this->assertEquals( 'tag2', $tags[1]->slug );
-		$this->assertEquals( 'tag3', $tags[2]->slug );
+		$this->assertCount( 3, $tags );
+		$this->assertSame( 'tag1', $tags[0]->slug );
+		$this->assertSame( 'tag2', $tags[1]->slug );
+		$this->assertSame( 'tag3', $tags[2]->slug );
 
 		$post = $posts[5];
-		$this->assertEquals( '1-col page', $post->post_title );
-		$this->assertEquals( '1-col-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'page', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
-		$this->assertEquals( 'onecolumn-page.php', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertSame( '1-col page', $post->post_title );
+		$this->assertSame( '1-col-page', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'page', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
+		$this->assertSame( 'onecolumn-page.php', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[6];
-		$this->assertEquals( 'Draft Page', $post->post_title );
-		$this->assertEquals( '', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'page', $post->post_type );
-		$this->assertEquals( 'draft', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
-		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertSame( 'Draft Page', $post->post_title );
+		$this->assertSame( '', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'page', $post->post_type );
+		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
+		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[7];
-		$this->assertEquals( 'Parent Page', $post->post_title );
-		$this->assertEquals( 'parent-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'page', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
-		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertSame( 'Parent Page', $post->post_title );
+		$this->assertSame( 'parent-page', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'page', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
+		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[8];
-		$this->assertEquals( 'Child Page', $post->post_title );
-		$this->assertEquals( 'child-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'page', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( $posts[7]->ID, $post->post_parent );
-		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertSame( 'Child Page', $post->post_title );
+		$this->assertSame( 'child-page', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'page', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( $posts[7]->ID, $post->post_parent );
+		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[9];
-		$this->assertEquals( 'Sample Page', $post->post_title );
-		$this->assertEquals( 'sample-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
-		$this->assertEquals( 'page', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
-		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertSame( 'Sample Page', $post->post_title );
+		$this->assertSame( 'sample-page', $post->post_name );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
+		$this->assertSame( 'page', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
+		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[10];
-		$this->assertEquals( 'Hello world!', $post->post_title );
-		$this->assertEquals( 'hello-world', $post->post_name );
-		$this->assertEquals( $author->ID, $post->post_author );
-		$this->assertEquals( 'post', $post->post_type );
-		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 0, $post->post_parent );
+		$this->assertSame( 'Hello world!', $post->post_title );
+		$this->assertSame( 'hello-world', $post->post_name );
+		$this->assertSame( (string) $author->ID, $post->post_author );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertSame( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertEquals( 1, count( $cats ) );
+		$this->assertCount( 1, $cats );
 	}
 
 	/**
@@ -242,57 +221,87 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/small-export.xml', $authors );
 
 		$user_count = count_users();
-		$this->assertEquals( 3, $user_count['total_users'] );
+		$this->assertSame( 3, $user_count['total_users'] );
 		$admin = get_user_by( 'login', 'admin' );
-		$this->assertEquals( 'admin', $admin->user_login );
-		$this->assertEquals( 'local@host.null', $admin->user_email );
+		$this->assertSame( 'admin', $admin->user_login );
+		$this->assertSame( 'local@host.null', $admin->user_email );
 		$editor = get_user_by( 'login', 'editor' );
-		$this->assertEquals( 'editor', $editor->user_login );
-		$this->assertEquals( 'editor@example.org', $editor->user_email );
-		$this->assertEquals( 'FirstName', $editor->user_firstname );
-		$this->assertEquals( 'LastName', $editor->user_lastname );
+		$this->assertSame( 'editor', $editor->user_login );
+		$this->assertSame( 'editor@example.org', $editor->user_email );
+		$this->assertSame( 'FirstName', $editor->user_firstname );
+		$this->assertSame( 'LastName', $editor->user_lastname );
 		$author = get_user_by( 'login', 'author' );
-		$this->assertEquals( 'author', $author->user_login );
-		$this->assertEquals( 'author@example.org', $author->user_email );
+		$this->assertSame( 'author', $author->user_login );
+		$this->assertSame( 'author@example.org', $author->user_email );
 
 		$this->assertSame( '30', wp_count_terms( array( 'taxonomy' => 'category' ) ) );
 		$this->assertSame( '3', wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
-		$this->assertEquals( 0, $foo->parent );
+		$this->assertSame( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
 		$foo_bar = get_term_by( 'slug', 'foo-bar', 'category' );
-		$this->assertEquals( $bar->term_id, $foo_bar->parent );
+		$this->assertSame( $bar->term_id, $foo_bar->parent );
 
 		$post_count = wp_count_posts( 'post' );
-		$this->assertEquals( 5, $post_count->publish );
-		$this->assertEquals( 1, $post_count->private );
+		$this->assertSame( '5', $post_count->publish );
+		$this->assertSame( '1', $post_count->private );
 		$page_count = wp_count_posts( 'page' );
-		$this->assertEquals( 4, $page_count->publish );
-		$this->assertEquals( 1, $page_count->draft );
+		$this->assertSame( '4', $page_count->publish );
+		$this->assertSame( '1', $page_count->draft );
 		$comment_count = wp_count_comments();
-		$this->assertEquals( 1, $comment_count->total_comments );
+		$this->assertSame( 1, $comment_count->total_comments );
 	}
 
-	function test_ordering_of_importers() {
-		global $wp_importers;
-		$_wp_importers = $wp_importers; // Preserve global state
-		$wp_importers  = array(
-			'xyz1' => array( 'xyz1' ),
-			'XYZ2' => array( 'XYZ2' ),
-			'abc2' => array( 'abc2' ),
-			'ABC1' => array( 'ABC1' ),
-			'def1' => array( 'def1' ),
-		);
-		$this->assertEquals(
+	/**
+	 * @ticket 21007
+	 *
+	 * @covers WP_Import::import
+	 */
+	public function test_slashes_should_not_be_stripped() {
+		global $wpdb;
+
+		$authors = array( 'admin' => false );
+		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/slashes.xml', $authors );
+
+		$alpha = get_term_by( 'slug', 'alpha', 'category' );
+		$this->assertSame( 'a \"great\" category', $alpha->name );
+
+		$tag1 = get_term_by( 'slug', 'tag1', 'post_tag' );
+		$this->assertSame( "foo\'bar", $tag1->name );
+
+		$posts = get_posts(
 			array(
-				'ABC1' => array( 'ABC1' ),
-				'abc2' => array( 'abc2' ),
-				'def1' => array( 'def1' ),
-				'xyz1' => array( 'xyz1' ),
-				'XYZ2' => array( 'XYZ2' ),
-			), get_importers()
+				'post_type'   => 'any',
+				'post_status' => 'any',
+			)
 		);
-		$wp_importers = $_wp_importers; // Restore global state
+		$this->assertNotEmpty( $posts );
+		$this->assertSame( 'Slashes aren\\\'t \"cool\"', $posts[0]->post_content );
+
+		$comments = get_comments(
+			array(
+				'post_id' => $posts[0]->post_ID,
+			)
+		);
+		$this->assertNotEmpty( $comments );
+		$this->assertSame( '\o/ ¯\_(ツ)_/¯', $comments[0]->comment_content );
+	}
+
+	/**
+	 * Ensure no PHP 8.1 deprecation notice is thrown when a URL is passed without a path component.
+	 *
+	 * Note: this test doesn't test anything else of the functionality in the `WP_Import::fetch_remote_file()` method!
+	 */
+	public function test_fetch_remote_file_php81_deprecation() {
+		$importer = new WP_Import();
+		$result   = $importer->fetch_remote_file( 'https://example.com', array() );
+
+		$this->assertWPError( $result, 'Call to fetch_remote_file() did not return expected WP Error object' );
+		$this->assertSame(
+			'Sorry, this file type is not permitted for security reasons.',
+			$result->get_error_message(),
+			'The WP Error object did not contain the expected error'
+		);
 	}
 
 	/**
@@ -301,7 +310,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 	public function test_flat_attachment_import_rewrites_attachment_url( $file, $rewrite_urls ) {
 		$this->previous_uploads_structure = get_option( 'uploads_use_yearmonth_folders', true );
 		update_option( 'uploads_use_yearmonth_folders', 0 );
-		
+
 		$remote_url  = 'https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg';
 		$image_bytes = base64_decode(
 			'/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCABkAGQDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPwB//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwB//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwB//9k',
@@ -337,7 +346,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertFileExists( $attached_file );
 
 		$localized_url = wp_get_attachment_url( $attachment->ID );
-		$this->assertStringStartsWith( "http://example.org/wp-content/uploads/canola2", $localized_url );
+		$this->assertStringStartsWith( 'http://example.org/wp-content/uploads/canola2', $localized_url );
 
 		$posts = get_posts(
 			array(
@@ -348,14 +357,14 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertCount( 1, $posts, 'Expected the post to be imported.' );
 
 		$post = $posts[0];
-		$this->assertContains( "http://example.org/wp-content/uploads/canola2", $post->post_content );
+		$this->assertContains( 'http://example.org/wp-content/uploads/canola2', $post->post_content );
 	}
 
-	static public function data_flat_attachment_import_rewrites_attachment_url() {
+	public static function data_flat_attachment_import_rewrites_attachment_url() {
 		return array(
-			'Same-site attachments with URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-same-site.xml', true ),
-			'Same-site attachments with no URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-same-site.xml', false ),
-			'Cross-site attachments with URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-different-site.xml', true ),
+			'Same-site attachments with URL rewriting'     => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-same-site.xml', true ),
+			'Same-site attachments with no URL rewriting'  => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-same-site.xml', false ),
+			'Cross-site attachments with URL rewriting'    => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-different-site.xml', true ),
 			'Cross-site attachments with no URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-different-site.xml', false ),
 		);
 	}
@@ -384,66 +393,14 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 		return array(
 			'headers'  => array(
-				'content-length'  => (string) strlen( $this->mocked_attachment_body ),
-				'content-type'    => 'image/jpeg',
+				'content-length' => (string) strlen( $this->mocked_attachment_body ),
+				'content-type'   => 'image/jpeg',
 			),
 			'body'     => '',
 			'response' => array(
 				'code'    => 200,
 				'message' => 'OK',
 			),
-		);
-	}
-
-	/**
-	 * @ticket 21007
-	 *
-	 * @covers WP_Import::import
-	 */
-	public function test_slashes_should_not_be_stripped() {
-		global $wpdb;
-
-		$authors = array( 'admin' => false );
-		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/slashes.xml', $authors );
-
-		$alpha = get_term_by( 'slug', 'alpha', 'category' );
-		$this->assertSame( 'a \"great\" category', $alpha->name );
-
-		$tag1 = get_term_by( 'slug', 'tag1', 'post_tag' );
-		$this->assertSame( "foo\'bar", $tag1->name );
-
-		$posts = get_posts(
-			array(
-				'post_type'   => 'any',
-				'post_status' => 'any',
-			)
-		);
-		$this->assertNotEmpty( $posts );
-		$this->assertSame( 'Slashes aren\\\'t \"cool\"', $posts[0]->post_content );
-
-		$comments = get_comments(
-			array(
-				'post_id' => $posts[0]->post_ID
-			)
-		);
-		$this->assertNotEmpty( $comments );
-		$this->assertSame( '\o/ ¯\_(ツ)_/¯', $comments[0]->comment_content );
-	}
-
-	/**
-	 * Ensure no PHP 8.1 deprecation notice is thrown when a URL is passed without a path component.
-	 *
-	 * Note: this test doesn't test anything else of the functionality in the `WP_Import::fetch_remote_file()` method!
-	 */
-	public function test_fetch_remote_file_php81_deprecation() {
-		$importer = new WP_Import();
-		$result   = $importer->fetch_remote_file( 'https://example.com', array() );
-
-		$this->assertWPError( $result, 'Call to fetch_remote_file() did not return expected WP Error object' );
-		$this->assertSame(
-			'Sorry, this file type is not permitted for security reasons.',
-			$result->get_error_message(),
-			'The WP Error object did not contain the expected error'
 		);
 	}
 }

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -6,6 +6,27 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
+	/**
+	 * Holds the URL currently mocked for HTTP requests when downloading attachments.
+	 *
+	 * @var string
+	 */
+	private $mocked_attachment_url = '';
+
+	/**
+	 * Binary contents returned for the mocked attachment download.
+	 *
+	 * @var string
+	 */
+	private $mocked_attachment_body = '';
+
+	/**
+	 * Previous value of the uploads year/month folders option.
+	 *
+	 * @var mixed
+	 */
+	private $previous_uploads_structure = null;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -29,6 +50,11 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 	public function tear_down() {
 		remove_filter( 'import_allow_create_users', '__return_true' );
 
+		if ( null !== $this->previous_uploads_structure ) {
+			update_option( 'uploads_use_yearmonth_folders', $this->previous_uploads_structure );
+			$this->previous_uploads_structure = null;
+		}
+
 		parent::tear_down();
 	}
 
@@ -45,39 +71,39 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		);
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/small-export.xml', $authors );
 
-		// Ensure that authors were imported correctly.
+		// ensure that authors were imported correctly
 		$user_count = count_users();
-		$this->assertSame( 3, $user_count['total_users'] );
+		$this->assertEquals( 3, $user_count['total_users'] );
 		$admin = get_user_by( 'login', 'admin' );
-		$this->assertSame( 'admin', $admin->user_login );
-		$this->assertSame( 'local@host.null', $admin->user_email );
+		$this->assertEquals( 'admin', $admin->user_login );
+		$this->assertEquals( 'local@host.null', $admin->user_email );
 		$editor = get_user_by( 'login', 'editor' );
-		$this->assertSame( 'editor', $editor->user_login );
-		$this->assertSame( 'editor@example.org', $editor->user_email );
-		$this->assertSame( 'FirstName', $editor->user_firstname );
-		$this->assertSame( 'LastName', $editor->user_lastname );
+		$this->assertEquals( 'editor', $editor->user_login );
+		$this->assertEquals( 'editor@example.org', $editor->user_email );
+		$this->assertEquals( 'FirstName', $editor->user_firstname );
+		$this->assertEquals( 'LastName', $editor->user_lastname );
 		$author = get_user_by( 'login', 'author' );
-		$this->assertSame( 'author', $author->user_login );
-		$this->assertSame( 'author@example.org', $author->user_email );
+		$this->assertEquals( 'author', $author->user_login );
+		$this->assertEquals( 'author@example.org', $author->user_email );
 
 		// Check that terms were imported correctly.
 		$this->assertSame( '30', wp_count_terms( array( 'taxonomy' => 'category' ) ) );
 		$this->assertSame( '3', wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
-		$this->assertSame( 0, $foo->parent );
+		$this->assertEquals( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
 		$foo_bar = get_term_by( 'slug', 'foo-bar', 'category' );
-		$this->assertSame( $bar->term_id, $foo_bar->parent );
+		$this->assertEquals( $bar->term_id, $foo_bar->parent );
 
-		// Check that posts/pages were imported correctly.
+		// check that posts/pages were imported correctly
 		$post_count = wp_count_posts( 'post' );
-		$this->assertSame( '5', $post_count->publish );
-		$this->assertSame( '1', $post_count->private );
+		$this->assertEquals( 5, $post_count->publish );
+		$this->assertEquals( 1, $post_count->private );
 		$page_count = wp_count_posts( 'page' );
-		$this->assertSame( '4', $page_count->publish );
-		$this->assertSame( '1', $page_count->draft );
+		$this->assertEquals( 4, $page_count->publish );
+		$this->assertEquals( 1, $page_count->draft );
 		$comment_count = wp_count_comments();
-		$this->assertSame( 1, $comment_count->total_comments );
+		$this->assertEquals( 1, $comment_count->total_comments );
 
 		$posts = get_posts(
 			array(
@@ -87,120 +113,120 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 				'orderby'     => 'ID',
 			)
 		);
-		$this->assertCount( 11, $posts );
+		$this->assertEquals( 11, count( $posts ) );
 
 		$post = $posts[0];
-		$this->assertSame( 'Many Categories', $post->post_title );
-		$this->assertSame( 'many-categories', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'post', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
+		$this->assertEquals( 'Many Categories', $post->post_title );
+		$this->assertEquals( 'many-categories', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'post', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertCount( 27, $cats );
+		$this->assertEquals( 27, count( $cats ) );
 
 		$post = $posts[1];
-		$this->assertSame( 'Non-standard post format', $post->post_title );
-		$this->assertSame( 'non-standard-post-format', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'post', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
+		$this->assertEquals( 'Non-standard post format', $post->post_title );
+		$this->assertEquals( 'non-standard-post-format', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'post', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertCount( 1, $cats );
+		$this->assertEquals( 1, count( $cats ) );
 		$this->assertTrue( has_post_format( 'aside', $post->ID ) );
 
 		$post = $posts[2];
-		$this->assertSame( 'Top-level Foo', $post->post_title );
-		$this->assertSame( 'top-level-foo', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'post', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
+		$this->assertEquals( 'Top-level Foo', $post->post_title );
+		$this->assertEquals( 'top-level-foo', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'post', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID, array( 'fields' => 'all' ) );
-		$this->assertCount( 1, $cats );
-		$this->assertSame( 'foo', $cats[0]->slug );
+		$this->assertEquals( 1, count( $cats ) );
+		$this->assertEquals( 'foo', $cats[0]->slug );
 
 		$post = $posts[3];
-		$this->assertSame( 'Foo-child', $post->post_title );
-		$this->assertSame( 'foo-child', $post->post_name );
-		$this->assertSame( (string) $editor->ID, $post->post_author );
-		$this->assertSame( 'post', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
+		$this->assertEquals( 'Foo-child', $post->post_title );
+		$this->assertEquals( 'foo-child', $post->post_name );
+		$this->assertEquals( $editor->ID, $post->post_author );
+		$this->assertEquals( 'post', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID, array( 'fields' => 'all' ) );
-		$this->assertCount( 1, $cats );
-		$this->assertSame( 'foo-bar', $cats[0]->slug );
+		$this->assertEquals( 1, count( $cats ) );
+		$this->assertEquals( 'foo-bar', $cats[0]->slug );
 
 		$post = $posts[4];
-		$this->assertSame( 'Private Post', $post->post_title );
-		$this->assertSame( 'private-post', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'post', $post->post_type );
-		$this->assertSame( 'private', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
+		$this->assertEquals( 'Private Post', $post->post_title );
+		$this->assertEquals( 'private-post', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'post', $post->post_type );
+		$this->assertEquals( 'private', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertCount( 1, $cats );
+		$this->assertEquals( 1, count( $cats ) );
 		$tags = wp_get_post_tags( $post->ID );
-		$this->assertCount( 3, $tags );
-		$this->assertSame( 'tag1', $tags[0]->slug );
-		$this->assertSame( 'tag2', $tags[1]->slug );
-		$this->assertSame( 'tag3', $tags[2]->slug );
+		$this->assertEquals( 3, count( $tags ) );
+		$this->assertEquals( 'tag1', $tags[0]->slug );
+		$this->assertEquals( 'tag2', $tags[1]->slug );
+		$this->assertEquals( 'tag3', $tags[2]->slug );
 
 		$post = $posts[5];
-		$this->assertSame( '1-col page', $post->post_title );
-		$this->assertSame( '1-col-page', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'page', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
-		$this->assertSame( 'onecolumn-page.php', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertEquals( '1-col page', $post->post_title );
+		$this->assertEquals( '1-col-page', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'page', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
+		$this->assertEquals( 'onecolumn-page.php', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[6];
-		$this->assertSame( 'Draft Page', $post->post_title );
-		$this->assertSame( '', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'page', $post->post_type );
-		$this->assertSame( 'draft', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
-		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertEquals( 'Draft Page', $post->post_title );
+		$this->assertEquals( '', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'page', $post->post_type );
+		$this->assertEquals( 'draft', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
+		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[7];
-		$this->assertSame( 'Parent Page', $post->post_title );
-		$this->assertSame( 'parent-page', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'page', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
-		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertEquals( 'Parent Page', $post->post_title );
+		$this->assertEquals( 'parent-page', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'page', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
+		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[8];
-		$this->assertSame( 'Child Page', $post->post_title );
-		$this->assertSame( 'child-page', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'page', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( $posts[7]->ID, $post->post_parent );
-		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertEquals( 'Child Page', $post->post_title );
+		$this->assertEquals( 'child-page', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'page', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( $posts[7]->ID, $post->post_parent );
+		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[9];
-		$this->assertSame( 'Sample Page', $post->post_title );
-		$this->assertSame( 'sample-page', $post->post_name );
-		$this->assertSame( (string) $admin->ID, $post->post_author );
-		$this->assertSame( 'page', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
-		$this->assertSame( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
+		$this->assertEquals( 'Sample Page', $post->post_title );
+		$this->assertEquals( 'sample-page', $post->post_name );
+		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertEquals( 'page', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
+		$this->assertEquals( 'default', get_post_meta( $post->ID, '_wp_page_template', true ) );
 
 		$post = $posts[10];
-		$this->assertSame( 'Hello world!', $post->post_title );
-		$this->assertSame( 'hello-world', $post->post_name );
-		$this->assertSame( (string) $author->ID, $post->post_author );
-		$this->assertSame( 'post', $post->post_type );
-		$this->assertSame( 'publish', $post->post_status );
-		$this->assertSame( 0, $post->post_parent );
+		$this->assertEquals( 'Hello world!', $post->post_title );
+		$this->assertEquals( 'hello-world', $post->post_name );
+		$this->assertEquals( $author->ID, $post->post_author );
+		$this->assertEquals( 'post', $post->post_type );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 0, $post->post_parent );
 		$cats = wp_get_post_categories( $post->ID );
-		$this->assertCount( 1, $cats );
+		$this->assertEquals( 1, count( $cats ) );
 	}
 
 	/**
@@ -216,35 +242,157 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->_import_wp( DIR_TESTDATA_WP_IMPORTER . '/small-export.xml', $authors );
 
 		$user_count = count_users();
-		$this->assertSame( 3, $user_count['total_users'] );
+		$this->assertEquals( 3, $user_count['total_users'] );
 		$admin = get_user_by( 'login', 'admin' );
-		$this->assertSame( 'admin', $admin->user_login );
-		$this->assertSame( 'local@host.null', $admin->user_email );
+		$this->assertEquals( 'admin', $admin->user_login );
+		$this->assertEquals( 'local@host.null', $admin->user_email );
 		$editor = get_user_by( 'login', 'editor' );
-		$this->assertSame( 'editor', $editor->user_login );
-		$this->assertSame( 'editor@example.org', $editor->user_email );
-		$this->assertSame( 'FirstName', $editor->user_firstname );
-		$this->assertSame( 'LastName', $editor->user_lastname );
+		$this->assertEquals( 'editor', $editor->user_login );
+		$this->assertEquals( 'editor@example.org', $editor->user_email );
+		$this->assertEquals( 'FirstName', $editor->user_firstname );
+		$this->assertEquals( 'LastName', $editor->user_lastname );
 		$author = get_user_by( 'login', 'author' );
-		$this->assertSame( 'author', $author->user_login );
-		$this->assertSame( 'author@example.org', $author->user_email );
+		$this->assertEquals( 'author', $author->user_login );
+		$this->assertEquals( 'author@example.org', $author->user_email );
 
 		$this->assertSame( '30', wp_count_terms( array( 'taxonomy' => 'category' ) ) );
 		$this->assertSame( '3', wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
-		$this->assertSame( 0, $foo->parent );
+		$this->assertEquals( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
 		$foo_bar = get_term_by( 'slug', 'foo-bar', 'category' );
-		$this->assertSame( $bar->term_id, $foo_bar->parent );
+		$this->assertEquals( $bar->term_id, $foo_bar->parent );
 
 		$post_count = wp_count_posts( 'post' );
-		$this->assertSame( '5', $post_count->publish );
-		$this->assertSame( '1', $post_count->private );
+		$this->assertEquals( 5, $post_count->publish );
+		$this->assertEquals( 1, $post_count->private );
 		$page_count = wp_count_posts( 'page' );
-		$this->assertSame( '4', $page_count->publish );
-		$this->assertSame( '1', $page_count->draft );
+		$this->assertEquals( 4, $page_count->publish );
+		$this->assertEquals( 1, $page_count->draft );
 		$comment_count = wp_count_comments();
-		$this->assertSame( 1, $comment_count->total_comments );
+		$this->assertEquals( 1, $comment_count->total_comments );
+	}
+
+	function test_ordering_of_importers() {
+		global $wp_importers;
+		$_wp_importers = $wp_importers; // Preserve global state
+		$wp_importers  = array(
+			'xyz1' => array( 'xyz1' ),
+			'XYZ2' => array( 'XYZ2' ),
+			'abc2' => array( 'abc2' ),
+			'ABC1' => array( 'ABC1' ),
+			'def1' => array( 'def1' ),
+		);
+		$this->assertEquals(
+			array(
+				'ABC1' => array( 'ABC1' ),
+				'abc2' => array( 'abc2' ),
+				'def1' => array( 'def1' ),
+				'xyz1' => array( 'xyz1' ),
+				'XYZ2' => array( 'XYZ2' ),
+			), get_importers()
+		);
+		$wp_importers = $_wp_importers; // Restore global state
+	}
+
+	/**
+	 * @dataProvider data_flat_attachment_import_rewrites_attachment_url
+	 */
+	public function test_flat_attachment_import_rewrites_attachment_url( $file, $rewrite_urls ) {
+		$this->previous_uploads_structure = get_option( 'uploads_use_yearmonth_folders', true );
+		update_option( 'uploads_use_yearmonth_folders', 0 );
+		
+		$remote_url  = 'https://wpthemetestdata.files.wordpress.com/2008/06/canola2.jpg';
+		$image_bytes = base64_decode(
+			'/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCABkAGQDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAQABPwB//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwB//8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwB//9k',
+			true
+		);
+		$this->assertNotFalse( $image_bytes, 'Failed to decode mock attachment image.' );
+
+		$this->mocked_attachment_url  = $remote_url;
+		$this->mocked_attachment_body = $image_bytes;
+
+		add_filter( 'pre_http_request', array( $this, 'filter_mock_attachment_request' ), 10, 3 );
+
+		try {
+			$this->_import_wp( $file, array(), true, $rewrite_urls );
+		} finally {
+			remove_filter( 'pre_http_request', array( $this, 'filter_mock_attachment_request' ), 10 );
+			$this->mocked_attachment_url  = '';
+			$this->mocked_attachment_body = '';
+		}
+
+		$attachments = get_posts(
+			array(
+				'numberposts' => -1,
+				'post_type'   => 'attachment',
+				'post_status' => 'inherit',
+			)
+		);
+		$this->assertCount( 1, $attachments, 'Expected the attachment post to be imported.' );
+
+		$attachment    = $attachments[0];
+		$attached_file = get_attached_file( $attachment->ID );
+		$this->assertNotFalse( $attached_file );
+		$this->assertFileExists( $attached_file );
+
+		$localized_url = wp_get_attachment_url( $attachment->ID );
+		$this->assertStringStartsWith( "http://example.org/wp-content/uploads/canola2", $localized_url );
+
+		$posts = get_posts(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'any',
+			)
+		);
+		$this->assertCount( 1, $posts, 'Expected the post to be imported.' );
+
+		$post = $posts[0];
+		$this->assertContains( "http://example.org/wp-content/uploads/canola2", $post->post_content );
+	}
+
+	static public function data_flat_attachment_import_rewrites_attachment_url() {
+		return array(
+			'Same-site attachments with URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-same-site.xml', true ),
+			'Same-site attachments with no URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-same-site.xml', false ),
+			'Cross-site attachments with URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-different-site.xml', true ),
+			'Cross-site attachments with no URL rewriting' => array( DIR_TESTDATA_WP_IMPORTER . '/wxr-flat-attachment-different-site.xml', false ),
+		);
+	}
+
+	/**
+	 * Provides a mocked HTTP response when the importer downloads attachments.
+	 *
+	 * @param false|array|WP_Error $preempt     Preempted response.
+	 * @param array                $parsed_args Parsed HTTP arguments.
+	 * @param string               $url         Requested URL.
+	 * @return false|array|WP_Error HTTP response override when mocking, otherwise original value.
+	 */
+	public function filter_mock_attachment_request( $preempt, $parsed_args, $url ) {
+		if ( $url !== $this->mocked_attachment_url || '' === $this->mocked_attachment_body ) {
+			return $preempt;
+		}
+
+		if ( empty( $parsed_args['filename'] ) ) {
+			return $preempt;
+		}
+
+		$result = file_put_contents( $parsed_args['filename'], $this->mocked_attachment_body );
+		if ( false === $result ) {
+			return new WP_Error( 'test_mock_http_write_failed', 'Failed to write mocked attachment response.' );
+		}
+
+		return array(
+			'headers'  => array(
+				'content-length'  => (string) strlen( $this->mocked_attachment_body ),
+				'content-type'    => 'image/jpeg',
+			),
+			'body'     => '',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
 	}
 
 	/**
@@ -275,7 +423,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 		$comments = get_comments(
 			array(
-				'post_id' => $posts[0]->post_ID,
+				'post_id' => $posts[0]->post_ID
 			)
 		);
 		$this->assertNotEmpty( $comments );

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -9,6 +9,8 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 	protected $previous_uploads_structure;
 
+	protected $mocked_attachment_url;
+
 	public function set_up() {
 		parent::set_up();
 

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -8,8 +8,8 @@ require_once __DIR__ . '/base.php';
 class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 	protected $previous_uploads_structure;
-
 	protected $mocked_attachment_url;
+	protected $mocked_attachment_body;
 
 	public function set_up() {
 		parent::set_up();

--- a/phpunit/tests/import.php
+++ b/phpunit/tests/import.php
@@ -6,6 +6,9 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
+
+	protected $previous_uploads_structure;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -357,7 +360,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertCount( 1, $posts, 'Expected the post to be imported.' );
 
 		$post = $posts[0];
-		$this->assertContains( 'http://example.org/wp-content/uploads/canola2', $post->post_content );
+		$this->assertStringContainsString( 'http://example.org/wp-content/uploads/canola2', $post->post_content );
 	}
 
 	public static function data_flat_attachment_import_rewrites_attachment_url() {

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1303,26 +1303,26 @@ class WP_Import extends WP_Importer {
 		/**
 		 * When URL rewriting is enabled, posts such as this one:
 		 *
-		 *     <img src="https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg" />
+		 *     <img src="https://example.com/subpath/wp-content/uploads/2008/06/canola2.jpg" />
 		 *
 		 * Are already stored as:
 		 *
-		 *     <img src="https://my-new-site.com/wp-content/uploads/2008/06/canola2.jpg" />
+		 *     <img src="https://example.org/wp-content/uploads/2008/06/canola2.jpg" />
 		 *
 		 * Therefore, we can't just remap the old URL to the new URL here. This substring
 		 * is no longer present in the post:
 		 *
-		 *     https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg
+		 *     https://example.com/subpath/wp-content/uploads/2008/06/canola2.jpg
 		 *
 		 * We need to replace the base URL in the media file URL the same way as we did
 		 * in the post content:
 		 *
-		 *     https://my-new-site.com/wp-content/uploads/2008/06/canola2.jpg
+		 *     https://example.org/wp-content/uploads/2008/06/canola2.jpg
 		 *
 		 * Only from there we can remap that URL to the new media files URL:
 		 *
-		 *     https://my-new-site.com/wp-content/uploads/canola2.jpg"
-		 *                                               ^ there may be no 2008/06 on the target site.
+		 *     https://example.org/wp-content/uploads/canola2.jpg"
+		 *                                            ^ there may be no 2008/06 on the target site.
 		 */
 		if ( $this->options['rewrite_urls'] ) {
 			$url          = WPURL::replace_base_url(

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1301,24 +1301,30 @@ class WP_Import extends WP_Importer {
 		);
 
 		// keep track of the old and new urls so we can substitute them later
-		if($this->options['rewrite_urls']) {
+		if ( $this->options['rewrite_urls'] ) {
 			// TODO: nicer code style, don't override the old variables maybe
-			$url = WPURL::replace_base_url([
-				'url' => $url,
-				'old_base_url' => $this->base_url_parsed,
-				'new_base_url' => $this->site_url_parsed
-			]);
-			$post['guid'] = WPURL::replace_base_url([
-				'url' => $post['guid'],
-				'old_base_url' => $this->base_url_parsed,
-				'new_base_url' => $this->site_url_parsed
-			]);
-			if ( isset( $headers['x-final-location'] ) ) {
-				$headers['x-final-location'] = WPURL::replace_base_url([
-					'url' => $headers['x-final-location'],
+			$url          = WPURL::replace_base_url(
+				array(
+					'url'          => $url,
 					'old_base_url' => $this->base_url_parsed,
-					'new_base_url' => $this->site_url_parsed
-				]);
+					'new_base_url' => $this->site_url_parsed,
+				)
+			);
+			$post['guid'] = WPURL::replace_base_url(
+				array(
+					'url'          => $post['guid'],
+					'old_base_url' => $this->base_url_parsed,
+					'new_base_url' => $this->site_url_parsed,
+				)
+			);
+			if ( isset( $headers['x-final-location'] ) ) {
+				$headers['x-final-location'] = WPURL::replace_base_url(
+					array(
+						'url'          => $headers['x-final-location'],
+						'old_base_url' => $this->base_url_parsed,
+						'new_base_url' => $this->site_url_parsed,
+					)
+				);
 			}
 		}
 

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -798,7 +798,7 @@ class WP_Import extends WP_Importer {
 					'post_password'  => $post['post_password'],
 				);
 
-				if ( $this->options['rewrite_urls'] && 0 ) {
+				if ( $this->options['rewrite_urls'] ) {
 					$url_mapping              = array(
 						$this->base_url_parsed->toString() => $this->site_url_parsed,
 					);

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1300,9 +1300,31 @@ class WP_Import extends WP_Importer {
 			'error' => false,
 		);
 
-		// keep track of the old and new urls so we can substitute them later
+		/**
+		 * When URL rewriting is enabled, posts such as this one:
+		 *
+		 *     <img src="https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg" />
+		 *
+		 * Are already stored as:
+		 *
+		 *     <img src="https://my-new-site.com/wp-content/uploads/2008/06/canola2.jpg" />
+		 *
+		 * Therefore, we can't just remap the old URL to the new URL here. This substring
+		 * is no longer present in the post:
+		 *
+		 *     https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg
+		 *
+		 * We need to replace the base URL in the media file URL the same way as we did
+		 * in the post content:
+		 *
+		 *     https://my-new-site.com/wp-content/uploads/2008/06/canola2.jpg
+		 *
+		 * Only from there we can remap that URL to the new media files URL:
+		 *
+		 *     https://my-new-site.com/wp-content/uploads/canola2.jpg"
+		 *                                               ^ there may be no 2008/06 on the target site.
+		 */
 		if ( $this->options['rewrite_urls'] ) {
-			// TODO: nicer code style, don't override the old variables maybe
 			$url          = WPURL::replace_base_url(
 				array(
 					'url'          => $url,

--- a/src/php-toolkit/DataLiberation/URL/class-wpurl.php
+++ b/src/php-toolkit/DataLiberation/URL/class-wpurl.php
@@ -26,7 +26,9 @@ class WPURL {
 	}
 
 	/**
-	 * Replaces the base URL for a parsed URL while preserving the remaining path/query/hash.
+	 * Replaces the base in a URL with a different base.
+	 * 
+	 * A base is a protocol, host, and a path segment. 
 	 *
 	 * Expected options:
 	 * - url (string|URL): The URL whose base should be replaced. Required.
@@ -86,6 +88,12 @@ class WPURL {
 			$updated_url->pathname = $to_pathname_with_trailing_slash . $remaining_pathname;
 		}
 
+		/*
+		 * Stylistic choice – if the updated URL has no trailing slash,
+		 * do not add it to the new URL. The WHATWG URL parser will
+		 * add one automatically if the path is empty, so we have to
+		 * explicitly remove it.
+		 */
 		$new_raw_url                = $updated_url->toString();
 		$should_trim_trailing_slash = (
 			'' !== $from_pathname &&

--- a/src/php-toolkit/DataLiberation/URL/class-wpurl.php
+++ b/src/php-toolkit/DataLiberation/URL/class-wpurl.php
@@ -27,8 +27,8 @@ class WPURL {
 
 	/**
 	 * Replaces the base in a URL with a different base.
-	 * 
-	 * A base is a protocol, host, and a path segment. 
+	 *
+	 * A base is a protocol, host, and a path segment.
 	 *
 	 * Expected options:
 	 * - url (string|URL): The URL whose base should be replaced. Required.

--- a/src/php-toolkit/DataLiberation/URL/class-wpurl.php
+++ b/src/php-toolkit/DataLiberation/URL/class-wpurl.php
@@ -26,6 +26,118 @@ class WPURL {
 	}
 
 	/**
+	 * Replaces the base URL for a parsed URL while preserving the remaining path/query/hash.
+	 *
+	 * Expected options:
+	 * - url (string|URL): The URL whose base should be replaced. Required.
+	 * - old_base_url (string|URL): The base URL currently associated with the URL. Required.
+	 * - new_base_url (string|URL): The base URL that should replace the existing one. Required.
+	 * - raw_url (string, optional): The original raw URL string. Used to detect relativity.
+	 * - is_relative (bool, optional): Whether the original URL was relative. Overrides raw_url detection.
+	 * - return_array (bool, optional): Whether to return the detailed array structure. Default false.
+	 *
+	 * @param array $options The options that control how the base URL is replaced.
+	 *
+	 * @return string|array|false Returns a string by default, or an array with keys 'url', 'string',
+	 *                           'relative_url', and 'was_relative' when 'return_array' is truthy.
+	 *                           Returns false on failure.
+	 */
+	public static function replace_base_url( $options ) {
+		if ( ! is_array( $options ) ) {
+			return false;
+		}
+
+		foreach ( array( 'url', 'old_base_url', 'new_base_url' ) as $required ) {
+			if ( ! array_key_exists( $required, $options ) || null === $options[ $required ] ) {
+				return false;
+			}
+		}
+
+		$old_base_url = self::parse( $options['old_base_url'] );
+		$new_base_url = self::parse( $options['new_base_url'] );
+		$url          = self::parse( $options['url'], $old_base_url ? $old_base_url->toString() : null );
+
+		if ( false === $old_base_url || false === $new_base_url || false === $url ) {
+			return false;
+		}
+
+		$updated_url = clone $url;
+
+		$updated_url->hostname = $new_base_url->hostname;
+		$updated_url->protocol = $new_base_url->protocol;
+		$updated_url->port     = $new_base_url->port;
+
+		$from_pathname = $url->pathname;
+		$to_pathname   = $new_base_url->pathname;
+		$base_pathname = $old_base_url->pathname;
+
+		if ( $base_pathname !== $to_pathname ) {
+			$base_pathname_with_trailing_slash = rtrim( $base_pathname, '/' ) . '/';
+			$decoded_matched_pathname          = urldecode_n(
+				$from_pathname,
+				strlen( $base_pathname_with_trailing_slash )
+			);
+			$to_pathname_with_trailing_slash   = rtrim( $to_pathname, '/' ) . '/';
+			$remaining_pathname                = substr(
+				$decoded_matched_pathname,
+				strlen( $base_pathname_with_trailing_slash )
+			);
+
+			$updated_url->pathname = $to_pathname_with_trailing_slash . $remaining_pathname;
+		}
+
+		$new_raw_url = $updated_url->toString();
+		$should_trim_trailing_slash = (
+			'' !== $from_pathname &&
+			'/' !== substr( $from_pathname, -1 ) &&
+			'/' !== $from_pathname &&
+			'' === $url->search &&
+			'' === $url->hash
+		);
+		if ( $should_trim_trailing_slash ) {
+			$new_raw_url = rtrim( $new_raw_url, '/' );
+		}
+		if ( ! $new_raw_url ) {
+			return false;
+		}
+
+		$was_relative = null;
+		if ( array_key_exists( 'is_relative', $options ) ) {
+			$was_relative = $options['is_relative'];
+		}
+		if ( null === $was_relative && array_key_exists( 'raw_url', $options ) && is_string( $options['raw_url'] ) ) {
+			$was_relative = ! self::can_parse( $options['raw_url'] );
+		}
+		if ( null === $was_relative ) {
+			$was_relative = false;
+		}
+
+		$relative_url = null;
+		if ( $was_relative ) {
+			$relative_url = $updated_url->pathname;
+			if ( '' !== $updated_url->search ) {
+				$relative_url .= $updated_url->search;
+			}
+			if ( '' !== $updated_url->hash ) {
+				$relative_url .= $updated_url->hash;
+			}
+		}
+
+		$result = array(
+			'url'          => $updated_url,
+			'string'       => $new_raw_url,
+			'relative_url' => $relative_url,
+			'was_relative' => (bool) $was_relative,
+		);
+
+		if ( empty( $options['return_array'] ) ) {
+			return $result['string'];
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Prepends a protocol to any matched URL without the double slash.
 	 *
 	 * Imagine we have a base URL of `https://example.com` and a text like `Visit myblog.com`.

--- a/src/php-toolkit/DataLiberation/URL/class-wpurl.php
+++ b/src/php-toolkit/DataLiberation/URL/class-wpurl.php
@@ -86,7 +86,7 @@ class WPURL {
 			$updated_url->pathname = $to_pathname_with_trailing_slash . $remaining_pathname;
 		}
 
-		$new_raw_url = $updated_url->toString();
+		$new_raw_url                = $updated_url->toString();
 		$should_trim_trailing_slash = (
 			'' !== $from_pathname &&
 			'/' !== substr( $from_pathname, -1 ) &&


### PR DESCRIPTION
Ensures the correct remapping of URLs referencing media files found in the imported posts when URL rewriting is enabled.

Solves https://github.com/WordPress/wordpress-importer/issues/217

### Problem

When URL rewriting is enabled, posts such as this one:

```html
<img src="https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg" />
```

Are imported as:

```html
<img src="https://my-new-site.com/wp-content/uploads/2008/06/canola2.jpg" />
```

The media URL rewriting, however, tries to do a second pass over the imported content to replace the original media URL with the current site's media URL. Assuming we're importing from a `YYYY/MM/{filename}` uploads structure to a flat `{filename}` structure, that media rewriting step would try to replace

```
https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg
```

with 

```
https://my-new-site.com/wp-content/uploads/canola2.jpg
```

However, that initial URL no longer exists in the content as the base URL was already migrated.

### Solution

This PR migrates the base URL in the media-related `url_remap` entries to ensure we're replacing the URL that were effectively inserted into the database during the import. For example, it migrates `https://my-old-site.com/subpath/wp-content/uploads/2008/06/canola2.jpg` to `https://my-new-site.com/wp-content/uploads/2008/06/canola2.jpg` before creating a `url_remap` entry to migrate it to `https://my-new-site.com/wp-content/uploads/canola2.jpg`.

cc @zaerl