### PR TITLE
Prevent URL remapping for attachments without file extensions

### DIFF
--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -9,6 +9,7 @@
 use WordPress\DataLiberation\URL\WPURL;
 use function WordPress\DataLiberation\URL\wp_rewrite_urls;
 
+   
 /**
  * WordPress importer class.
  */
@@ -1356,21 +1357,22 @@ class WP_Import extends WP_Importer {
 		$post_id = wp_insert_attachment( $post, $upload['file'] );
 		wp_update_attachment_metadata( $post_id, wp_generate_attachment_metadata( $post_id, $upload['file'] ) );
 
-		// remap resized image URLs, works by stripping the extension and remapping the URL stub.
-	if ( preg_match( '!^image/!', $info['type'] ) ) {
-    $parts     = pathinfo( $url );
-    $parts_new = pathinfo( $upload['url'] );
+			// remap resized image URLs, works by stripping the extension and remapping the URL stub.
+		if ( preg_match( '!^image/!', $info['type'] ) ) {
+			$parts     = pathinfo( $url );
+			$parts_new = pathinfo( $upload['url'] );
 
-    if ( empty( $parts['extension'] ) || empty( $parts_new['extension'] ) ) {
-        return $post_id;
-    }
+			if ( empty( $parts['extension'] ) || empty( $parts_new['extension'] ) ) {
+				return $post_id;
+			}
 
-    $name     = basename( $parts['basename'], ".{$parts['extension']}" );
-    $name_new = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
+			$name     = basename( $parts['basename'], ".{$parts['extension']}" );
+			$name_new = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
 
-    $this->url_remap[ $parts['dirname'] . '/' . $name ] =
-        $parts_new['dirname'] . '/' . $name_new;
-}
+			$this->url_remap[ $parts['dirname'] . '/' . $name ] =
+				$parts_new['dirname'] . '/' . $name_new;
+		}
+
 
 
 		return $post_id;

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -1357,15 +1357,21 @@ class WP_Import extends WP_Importer {
 		wp_update_attachment_metadata( $post_id, wp_generate_attachment_metadata( $post_id, $upload['file'] ) );
 
 		// remap resized image URLs, works by stripping the extension and remapping the URL stub.
-		if ( preg_match( '!^image/!', $info['type'] ) ) {
-			$parts = pathinfo( $url );
-			$name  = basename( $parts['basename'], ".{$parts['extension']}" ); // PATHINFO_FILENAME in PHP 5.2
+	if ( preg_match( '!^image/!', $info['type'] ) ) {
+    $parts     = pathinfo( $url );
+    $parts_new = pathinfo( $upload['url'] );
 
-			$parts_new = pathinfo( $upload['url'] );
-			$name_new  = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
+    if ( empty( $parts['extension'] ) || empty( $parts_new['extension'] ) ) {
+        return $post_id;
+    }
 
-			$this->url_remap[ $parts['dirname'] . '/' . $name ] = $parts_new['dirname'] . '/' . $name_new;
-		}
+    $name     = basename( $parts['basename'], ".{$parts['extension']}" );
+    $name_new = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
+
+    $this->url_remap[ $parts['dirname'] . '/' . $name ] =
+        $parts_new['dirname'] . '/' . $name_new;
+}
+
 
 		return $post_id;
 	}

--- a/src/class-wp-import.php
+++ b/src/class-wp-import.php
@@ -9,10 +9,10 @@
 use WordPress\DataLiberation\URL\WPURL;
 use function WordPress\DataLiberation\URL\wp_rewrite_urls;
 
-   
 /**
  * WordPress importer class.
  */
+
 class WP_Import extends WP_Importer {
 	public $max_wxr_version = 1.2; // max. supported WXR version
 
@@ -1357,7 +1357,7 @@ class WP_Import extends WP_Importer {
 		$post_id = wp_insert_attachment( $post, $upload['file'] );
 		wp_update_attachment_metadata( $post_id, wp_generate_attachment_metadata( $post_id, $upload['file'] ) );
 
-			// remap resized image URLs, works by stripping the extension and remapping the URL stub.
+		// remap resized image URLs, works by stripping the extension and remapping the URL stub.
 		if ( preg_match( '!^image/!', $info['type'] ) ) {
 			$parts     = pathinfo( $url );
 			$parts_new = pathinfo( $upload['url'] );
@@ -1368,12 +1368,9 @@ class WP_Import extends WP_Importer {
 
 			$name     = basename( $parts['basename'], ".{$parts['extension']}" );
 			$name_new = basename( $parts_new['basename'], ".{$parts_new['extension']}" );
-
 			$this->url_remap[ $parts['dirname'] . '/' . $name ] =
 				$parts_new['dirname'] . '/' . $name_new;
 		}
-
-
 
 		return $post_id;
 	}


### PR DESCRIPTION
### Summary
Prevents incorrect URL remapping when importing externally hosted media files that do not include a file extension.

### Details
Adds a defensive check before remapping resized image URLs to ensure both source and destination URLs contain a valid extension.

### Related Issue
Fixes #186
