### PR TITLE
Fix: Update composer.json to run the test suites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "wp-coding-standards/wpcs": "^3.1",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "yoast/phpunit-polyfills": "^1.0.1",
-        "phpunit/phpunit": "^5.7.21 || ^6.5 || ^7.5"
+        "phpunit/phpunit": "^5.7.21 || ^6.5 || ^7.5 || ^8.5 || ^9",
+        "doctrine/instantiator": "^1.0"
     },
     "scripts": {
         "e2e": "npx -y playwright test --timeout 300000"


### PR DESCRIPTION
- Update composer.json to add phpunit version 8.5 and 9.
- Add `doctrine/instantiator` to instantiate objects. (Resolved unit test with php 8.2 WP latest and php 8.2 wp 6.2)